### PR TITLE
carddav: Remove duplicate package comment

### DIFF
--- a/carddav/fs.go
+++ b/carddav/fs.go
@@ -1,5 +1,3 @@
-// Package carddav provides a CardDAV server implementation, as defined in
-// RFC 6352.
 package carddav
 
 import (


### PR DESCRIPTION
The package comment is already present in [carddav.go](https://github.com/emersion/go-webdav/blob/f8d9f83cbc04bfb10f84848d3a2976345ce07bb0/carddav/carddav.go#L1-L2) file.

Having it in both places makes godoc show the documentation text twice. This can be seen at https://godoc.org/github.com/emersion/go-webdav/carddav at this time:

![image](https://user-images.githubusercontent.com/1924134/39833055-f7f2f69a-5396-11e8-9792-ece6d61d7055.png)