### PR TITLE
Add handling for carddav/caldav well-known urls

### DIFF
--- a/carddav/server.go
+++ b/carddav/server.go
@@ -36,6 +36,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/.well-known/carddav" {
+		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+		return
+	}
+
 	var err error
 	switch r.Method {
 	case "REPORT":


### PR DESCRIPTION
This pr adds handling of well-known URLs for both carddav and caldav. According to the [RFC 6764, Section 6](https://tools.ietf.org/html/rfc6764#section-6) the initial request for a client is a PROPFIND against `well-known/carddav`or `well-known/caldav`, which the server should reply to with a redirect to the proper endpoint (which here corresponds to the "/" url).

This might partially solve #30 