### PR TITLE
Return href together with a 404

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -134,17 +134,18 @@ func NewOKResponse(path string) *Response {
 	}
 }
 
-func (resp *Response) Path() (path string, err error) {
-	if len(resp.Hrefs) == 1 {
-		path = resp.Hrefs[0].Path // A sync response for a deleted entry has to have a href/path together with a 404. See https://tools.ietf.org/html/rfc6578#section-3.2
-	}
-	if err = resp.Status.Err(); err != nil {
-		return
+func (resp *Response) Path() (string, error) {
+	if err := resp.Status.Err(); err != nil {
+		if len(resp.Hrefs) == 1 {
+			path := resp.Hrefs[0].Path // A sync response for a deleted entry has to have a path together with a 404. See https://tools.ietf.org/html/rfc6578#section-3.2
+			return path, err
+		}
+		return "", err
 	}
 	if len(resp.Hrefs) != 1 {
-		err = fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
+		return "", fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
 	}
-	return
+	return resp.Hrefs[0].Path, nil
 }
 
 func (resp *Response) DecodeProp(values ...interface{}) error {

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -134,14 +134,17 @@ func NewOKResponse(path string) *Response {
 	}
 }
 
-func (resp *Response) Path() (string, error) {
-	if err := resp.Status.Err(); err != nil {
-		return "", err
+func (resp *Response) Path() (path string, err error) {
+	if len(resp.Hrefs) == 1 {
+		path = resp.Hrefs[0].Path // A sync response for a deleted entry has to have a href/path together with a 404. See https://tools.ietf.org/html/rfc6578#section-3.2
+	}
+	if err = resp.Status.Err(); err != nil {
+		return
 	}
 	if len(resp.Hrefs) != 1 {
-		return "", fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
+		err = fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
 	}
-	return resp.Hrefs[0].Path, nil
+	return
 }
 
 func (resp *Response) DecodeProp(values ...interface{}) error {

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -135,17 +135,14 @@ func NewOKResponse(path string) *Response {
 }
 
 func (resp *Response) Path() (string, error) {
-	if err := resp.Status.Err(); err != nil {
-		if len(resp.Hrefs) == 1 {
-			path := resp.Hrefs[0].Path // A sync response for a deleted entry has to have a path together with a 404. See https://tools.ietf.org/html/rfc6578#section-3.2
-			return path, err
-		}
-		return "", err
+	err := resp.Status.Err()
+	var path string
+	if len(resp.Hrefs) == 1 {
+		path = resp.Hrefs[0].Path
+	} else if err == nil {
+		err = fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
 	}
-	if len(resp.Hrefs) != 1 {
-		return "", fmt.Errorf("webdav: malformed response: expected exactly one href element, got %v", len(resp.Hrefs))
-	}
-	return resp.Hrefs[0].Path, nil
+	return path, err
 }
 
 func (resp *Response) DecodeProp(values ...interface{}) error {


### PR DESCRIPTION
In case of a card deletion, SyncCollection() responded with a SyncResponse.Deleted: [ "" ].
Instead of, a href should be returned together with a 404. Please see https://tools.ietf.org/html/rfc6578#section-3.2

The reason was the early exit (without a href/path) of Response.Path() in case of an error/404.

I slightly restructured Response.path() so that it remains simple and readable (without cascaded if's)