### PR TITLE
internal: use http.TimeFormat to marshal Time values

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -321,7 +321,7 @@ func (t *Time) UnmarshalText(b []byte) error {
 }
 
 func (t *Time) MarshalText() ([]byte, error) {
-	s := time.Time(*t).Format(time.RFC1123Z)
+	s := time.Time(*t).UTC().Format(http.TimeFormat)
 	return []byte(s), nil
 }
 

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -36,21 +36,24 @@ func TestMultistatus_Get_error(t *testing.T) {
 }
 
 func TestTimeRoundTrip(t *testing.T) {
-	buf := new(bytes.Buffer)
-	enc := xml.NewEncoder(buf)
-	now := Time(time.Now())
-	err := enc.Encode(now)
+	now := Time(time.Now().UTC())
+	want, err := now.MarshalText()
 	if err != nil {
-		t.Fatalf("could not encode time: %+v", err)
+		t.Fatalf("could not marshal time: %+v", err)
 	}
 
 	var got Time
-	err = xml.NewDecoder(buf).Decode(&got)
+	err = got.UnmarshalText(want)
 	if err != nil {
-		t.Fatalf("could not decode time: %+v", err)
+		t.Fatalf("could not unmarshal time: %+v", err)
 	}
 
-	if got, want := got, now; !got.Equal(want) {
-		t.Fatalf("invalid round-trip:\ngot= %+v\nwant=%+v", got, want)
+	raw, err := got.MarshalText()
+	if err != nil {
+		t.Fatalf("could not marshal back: %+v", err)
+	}
+
+	if got, want := raw, want; !bytes.Equal(got, want) {
+		t.Fatalf("invalid round-trip:\ngot= %s\nwant=%s", got, want)
 	}
 }

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -1,9 +1,11 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/xml"
 	"strings"
 	"testing"
+	"time"
 )
 
 // https://tools.ietf.org/html/rfc4918#section-9.6.2
@@ -30,5 +32,25 @@ func TestMultistatus_Get_error(t *testing.T) {
 		t.Errorf("Multistatus.Get() = %T, expected an *HTTPError", err)
 	} else if httpErr.Code != 423 {
 		t.Errorf("HTTPError.Code = %v, expected 423", httpErr.Code)
+	}
+}
+
+func TestTimeRoundTrip(t *testing.T) {
+	buf := new(bytes.Buffer)
+	enc := xml.NewEncoder(buf)
+	now := Time(time.Now())
+	err := enc.Encode(now)
+	if err != nil {
+		t.Fatalf("could not encode time: %+v", err)
+	}
+
+	var got Time
+	err = xml.NewDecoder(buf).Decode(&got)
+	if err != nil {
+		t.Fatalf("could not decode time: %+v", err)
+	}
+
+	if got, want := got, now; !got.Equal(want) {
+		t.Fatalf("invalid round-trip:\ngot= %+v\nwant=%+v", got, want)
 	}
 }


### PR DESCRIPTION
Fixes #47.

Signed-off-by: Sebastien Binet <binet@cern.ch>