### PR TITLE
Add error type representing DAV/XML errors

### DIFF
--- a/carddav/server.go
+++ b/carddav/server.go
@@ -439,3 +439,28 @@ func (b *backend) Copy(r *http.Request, dest *internal.Href, recursive, overwrit
 func (b *backend) Move(r *http.Request, dest *internal.Href, overwrite bool) (created bool, err error) {
 	panic("TODO")
 }
+
+// https://tools.ietf.org/rfcmarkup?doc=6352#section-6.3.2.1
+type PreconditionType string
+
+const (
+	PreconditionNoUIDConflict        PreconditionType = "no-uid-conflict"
+	PreconditionSupportedAddressData PreconditionType = "supported-address-data"
+	PreconditionValidAddressData     PreconditionType = "valid-address-data"
+	PreconditionMaxResourceSize      PreconditionType = "max-resource-size"
+)
+
+func NewPreconditionError(err PreconditionType) error {
+	name := xml.Name{"urn:ietf:params:xml:ns:carddav", string(err)}
+	elem := internal.NewRawXMLElement(name, nil, nil)
+	e := internal.Error{
+		Raw: []internal.RawXMLValue{
+			*elem,
+		},
+	}
+	return &internal.DAVError{
+		Code: 409,
+		Msg:  fmt.Sprintf("precondition not met: %s", string(err)),
+		Err:  e,
+	}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -99,3 +99,14 @@ func (err *HTTPError) Error() string {
 		return s
 	}
 }
+
+// DAVError is a XML error with HTTP status and a human readable message
+type DAVError struct {
+	Code int
+	Msg  string
+	Err  Error
+}
+
+func (err *DAVError) Error() string {
+	return err.Msg
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -10,6 +10,12 @@ import (
 )
 
 func ServeError(w http.ResponseWriter, err error) {
+	if davErr, ok := err.(*DAVError); ok {
+		w.WriteHeader(davErr.Code)
+		ServeXML(w).Encode(davErr.Err)
+		return
+	}
+
 	code := http.StatusInternalServerError
 	if httpErr, ok := err.(*HTTPError); ok {
 		code = httpErr.Code
@@ -102,11 +108,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		code := http.StatusInternalServerError
-		if httpErr, ok := err.(*HTTPError); ok {
-			code = httpErr.Code
-		}
-		http.Error(w, err.Error(), code)
+		ServeError(w, err)
 	}
 }
 


### PR DESCRIPTION
Backends will need some way to signal that a precondition error occurred
(and specifying which one) without causing the server to return a 500.
This commit adds an exported function to create a specific error for
this. The existing error handling routine is slightly adapted to handle
this error in such a way that it (almost) returns the desired result.

Usage would be something like:

    return "", carddav.PreconditionError("no-uid-conflict")

As is, this approach is missing a few things to be correct:

* Content-Type response header is text/plain, should be text/xml
* Response body is missing XML header (`<?xml ...`)

I'd like to get your opinion as early as possible before I start writing
more code.

Other approaches I could think of would be creating another, more
specific error type for this, using the context for communicating
specifics, or adding a third return value to the relevant interface
funcions.

What I think is nice about this approach is that it leaves the
interfaces as is and does not require handling of this kind of errors in
all the places they could occur.

What do you think?