### PR TITLE
Support custom user principal and home set paths

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -7,7 +7,13 @@ import (
 	"time"
 
 	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/internal"
 )
+
+func NewCalendarHomeSet(path string) webdav.BackendSuppliedHomeSet {
+	return &calendarHomeSet{Href: internal.Href{Path: path}}
+}
 
 type Calendar struct {
 	Path                  string

--- a/caldav/elements.go
+++ b/caldav/elements.go
@@ -31,6 +31,10 @@ type calendarHomeSet struct {
 	Href    internal.Href `xml:"DAV: href"`
 }
 
+func (a *calendarHomeSet) GetXMLName() xml.Name {
+	return calendarHomeSetName
+}
+
 // https://tools.ietf.org/html/rfc4791#section-5.2.1
 type calendarDescription struct {
 	XMLName     xml.Name `xml:"urn:ietf:params:xml:ns:caldav calendar-description"`

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -7,7 +7,13 @@ import (
 	"time"
 
 	"github.com/emersion/go-vcard"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/internal"
 )
+
+func NewAddressBookHomeSet(path string) webdav.BackendSuppliedHomeSet {
+	return &addressbookHomeSet{Href: internal.Href{Path: path}}
+}
 
 type AddressDataType struct {
 	ContentType string

--- a/carddav/elements.go
+++ b/carddav/elements.go
@@ -29,6 +29,10 @@ type addressbookHomeSet struct {
 	Href    internal.Href `xml:"DAV: href"`
 }
 
+func (a *addressbookHomeSet) GetXMLName() xml.Name {
+	return addressBookHomeSetName
+}
+
 type addressbookDescription struct {
 	XMLName     xml.Name `xml:"urn:ietf:params:xml:ns:carddav addressbook-description"`
 	Description string   `xml:",chardata"`

--- a/elements.go
+++ b/elements.go
@@ -1,0 +1,32 @@
+package webdav
+
+import (
+	"encoding/xml"
+
+	"github.com/emersion/go-webdav/internal"
+)
+
+var (
+	principalName                = xml.Name{"DAV:", "principal"}
+	principalAlternateURISetName = xml.Name{"DAV:", "alternate-URI-set"}
+	principalURLName             = xml.Name{"DAV:", "principal-URL"}
+	groupMembershipName          = xml.Name{"DAV:", "group-membership"}
+)
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.1
+type principalAlternateURISet struct {
+	XMLName xml.Name        `xml:"DAV: alternate-URI-set"`
+	Hrefs   []internal.Href `xml:"href"`
+}
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.2
+type principalURL struct {
+	XMLName xml.Name      `xml:"DAV: principal-URL"`
+	Href    internal.Href `xml:"href"`
+}
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.4
+type groupMembership struct {
+	XMLName xml.Name        `xml:"DAV: group-membership"`
+	Hrefs   []internal.Href `xml:"href"`
+}

--- a/server.go
+++ b/server.go
@@ -1,11 +1,13 @@
 package webdav
 
 import (
+	"context"
 	"encoding/xml"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/emersion/go-webdav/internal"
 )
@@ -233,4 +235,74 @@ func (b *backend) Move(r *http.Request, dest *internal.Href, overwrite bool) (cr
 		return false, &internal.HTTPError{http.StatusPreconditionFailed, err}
 	}
 	return created, err
+}
+
+// BackendSuppliedHomeSet represents either a CalDAV calendar-home-set or a
+// CardDAV addressbook-home-set. It should only be created via
+// `caldav.NewCalendarHomeSet()` or `carddav.NewAddressbookHomeSet()`. Only to
+// be used server-side, for listing a user's home sets as determined by the
+// (external) backend.
+type BackendSuppliedHomeSet interface {
+	GetXMLName() xml.Name
+}
+
+// UserPrincipalBackend can determine the current user's principal URL for a
+// given request context.
+type UserPrincipalBackend interface {
+	CurrentUserPrincipal(ctx context.Context) (string, error)
+}
+
+type ServeUserPrincipalOptions struct {
+	UserPrincipalPath string
+	HomeSets          []BackendSuppliedHomeSet
+}
+
+// ServeUserPrincipal replies to requests for the user principal URL
+func ServeUserPrincipal(w http.ResponseWriter, r *http.Request, options *ServeUserPrincipalOptions) {
+	switch r.Method {
+	case http.MethodOptions:
+		caps := []string{"1", "3"}
+		allow := []string{http.MethodOptions, "PROPFIND"}
+		w.Header().Add("DAV", strings.Join(caps, ", "))
+		w.Header().Add("Allow", strings.Join(allow, ", "))
+		w.WriteHeader(http.StatusNoContent)
+	case "PROPFIND":
+		if err := serveUserPrincipalPropfind(w, r, options); err != nil {
+			internal.ServeError(w, err)
+		}
+	default:
+		http.Error(w, "unsupported method", http.StatusMethodNotAllowed)
+	}
+}
+
+func serveUserPrincipalPropfind(w http.ResponseWriter, r *http.Request, options *ServeUserPrincipalOptions) error {
+	var propfind internal.Propfind
+	if err := internal.DecodeXMLRequest(r, &propfind); err != nil {
+		return err
+	}
+	props := map[xml.Name]internal.PropfindFunc{
+		internal.ResourceTypeName: func(*internal.RawXMLValue) (interface{}, error) {
+			return internal.NewResourceType(principalName), nil
+		},
+		internal.CurrentUserPrincipalName: func(*internal.RawXMLValue) (interface{}, error) {
+			return &internal.CurrentUserPrincipal{Href: internal.Href{Path: options.UserPrincipalPath}}, nil
+		},
+	}
+
+	// TODO: handle Depth and more properties
+
+	for _, homeSet := range options.HomeSets {
+		hs := homeSet // capture variable for closure
+		props[homeSet.GetXMLName()] = func(*internal.RawXMLValue) (interface{}, error) {
+			return hs, nil
+		}
+	}
+
+	resp, err := internal.NewPropfindResponse(r.URL.Path, &propfind, props)
+	if err != nil {
+		return err
+	}
+
+	ms := internal.NewMultistatus(*resp)
+	return internal.ServeMultistatus(w, ms)
 }


### PR DESCRIPTION
Currently, the user principal path and the home set path are both
hardcoded to "/", for both CalDAV and CardDAV. This poses a challenge if
one wishes to run a CardDAV and CalDAV server in the same server.

This commit introduces the concept of a UserPrincipalBackend. This
backend must provide the locations for the user principal as well as the
home sets. The CardDAV and CalDAV servers act accordingly.

The individual servers will continue to work as before (including the
option of keeping everything at "/"). If one wishes to run CardDAV and
CalDAV in parallel, the new `webdav.ServeUserPrincipal()` can be used,
which will use the UserPrincipalBackend interface to serve a common user
principal for both servers (if so desired, can be used for a single one
also).

Note that the storage backend will have to know about these paths as
well. For any non-trivial use case, a storage backend should probably
have access to the same UserPrincipalBackend. That is, however, an
implementation detail and doesn't have to be reflected in the
interfaces.