### PR TITLE
Support custom user principal and home set paths (v2)

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -7,7 +7,13 @@ import (
 	"time"
 
 	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/internal"
 )
+
+func NewCalendarHomeSet(path string) webdav.ListableHomeSet {
+	return &calendarHomeSet{Href: internal.Href{Path: path}}
+}
 
 type Calendar struct {
 	Path            string

--- a/caldav/elements.go
+++ b/caldav/elements.go
@@ -30,6 +30,10 @@ type calendarHomeSet struct {
 	Href    internal.Href `xml:"DAV: href"`
 }
 
+func (a *calendarHomeSet) GetXMLName() xml.Name {
+	return calendarHomeSetName
+}
+
 // https://tools.ietf.org/html/rfc4791#section-5.2.1
 type calendarDescription struct {
 	XMLName     xml.Name `xml:"urn:ietf:params:xml:ns:caldav calendar-description"`

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -7,7 +7,13 @@ import (
 	"time"
 
 	"github.com/emersion/go-vcard"
+	"github.com/emersion/go-webdav"
+	"github.com/emersion/go-webdav/internal"
 )
+
+func NewAddressBookHomeSet(path string) webdav.ListableHomeSet {
+	return &addressbookHomeSet{Href: internal.Href{Path: path}}
+}
 
 type AddressDataType struct {
 	ContentType string

--- a/carddav/elements.go
+++ b/carddav/elements.go
@@ -29,6 +29,10 @@ type addressbookHomeSet struct {
 	Href    internal.Href `xml:"DAV: href"`
 }
 
+func (a *addressbookHomeSet) GetXMLName() xml.Name {
+	return addressBookHomeSetName
+}
+
 type addressbookDescription struct {
 	XMLName     xml.Name `xml:"urn:ietf:params:xml:ns:carddav addressbook-description"`
 	Description string   `xml:",chardata"`

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"strings"
 
 	"github.com/emersion/go-vcard"
+	"github.com/emersion/go-webdav"
 	"github.com/emersion/go-webdav/internal"
 )
 
@@ -25,6 +27,7 @@ type PutAddressObjectOptions struct {
 
 // Backend is a CardDAV server backend.
 type Backend interface {
+	AddressbookHomeSetPath(ctx context.Context) (string, error)
 	AddressBook(ctx context.Context) (*AddressBook, error)
 	GetAddressObject(ctx context.Context, path string, req *AddressDataRequest) (*AddressObject, error)
 	ListAddressObjects(ctx context.Context, req *AddressDataRequest) ([]AddressObject, error)
@@ -46,23 +49,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	principalPath := string(webdav.CurrentUserPrincipalPathFromContext(r.Context()))
+
 	if r.URL.Path == "/.well-known/carddav" {
-		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+		http.Redirect(w, r, principalPath, http.StatusMovedPermanently)
 		return
 	}
 
-	var err error
 	switch r.Method {
 	case "REPORT":
-		err = h.handleReport(w, r)
+		if err := h.handleReport(w, r); err != nil {
+			internal.ServeError(w, err)
+		}
 	default:
 		b := backend{h.Backend}
 		hh := internal.Handler{&b}
 		hh.ServeHTTP(w, r)
-	}
-
-	if err != nil {
-		internal.ServeError(w, err)
 	}
 }
 
@@ -232,10 +234,21 @@ type backend struct {
 func (b *backend) Options(r *http.Request) (caps []string, allow []string, err error) {
 	caps = []string{"addressbook"}
 
-	if r.URL.Path == "/" {
+	homeSetPath, err := b.Backend.AddressbookHomeSetPath(r.Context())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	principalPath := string(webdav.CurrentUserPrincipalPathFromContext(r.Context()))
+
+	if r.URL.Path == "/" || r.URL.Path == principalPath || r.URL.Path == homeSetPath {
 		// Note: some clients assume the address book is read-only when
 		// DELETE/MKCOL are missing
 		return caps, []string{http.MethodOptions, "PROPFIND", "REPORT", "DELETE", "MKCOL"}, nil
+	}
+
+	if !strings.HasPrefix(r.URL.Path, homeSetPath) {
+		return nil, nil, &internal.HTTPError{Code: http.StatusMethodNotAllowed}
 	}
 
 	var dataReq AddressDataRequest
@@ -257,7 +270,11 @@ func (b *backend) Options(r *http.Request) (caps []string, allow []string, err e
 }
 
 func (b *backend) HeadGet(w http.ResponseWriter, r *http.Request) error {
-	if r.URL.Path == "/" {
+	homeSetPath, err := b.Backend.AddressbookHomeSetPath(r.Context())
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(r.URL.Path, homeSetPath) {
 		return &internal.HTTPError{Code: http.StatusMethodNotAllowed}
 	}
 
@@ -285,10 +302,24 @@ func (b *backend) HeadGet(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth internal.Depth) (*internal.Multistatus, error) {
+	homeSetPath, err := b.Backend.AddressbookHomeSetPath(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	principalPath := string(webdav.CurrentUserPrincipalPathFromContext(r.Context()))
+	isResourceRequest := !strings.HasPrefix(r.URL.Path, homeSetPath)
+
 	var dataReq AddressDataRequest
 
 	var resps []internal.Response
-	if r.URL.Path == "/" {
+
+	resp, err := b.propfindCommon(propfind, r.URL.Path, principalPath, homeSetPath)
+	if err != nil {
+		return nil, err
+	}
+	resps = append(resps, *resp)
+
+	if r.URL.Path == homeSetPath {
 		ab, err := b.Backend.AddressBook(r.Context())
 		if err != nil {
 			return nil, err
@@ -314,7 +345,7 @@ func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth i
 				resps = append(resps, *resp)
 			}
 		}
-	} else {
+	} else if isResourceRequest {
 		ao, err := b.Backend.GetAddressObject(r.Context(), r.URL.Path, &dataReq)
 		if err != nil {
 			return nil, err
@@ -328,6 +359,18 @@ func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth i
 	}
 
 	return internal.NewMultistatus(resps...), nil
+}
+
+func (b *backend) propfindCommon(propfind *internal.Propfind, path, principalPath, homeSetPath string) (*internal.Response, error) {
+	props := map[xml.Name]internal.PropfindFunc{
+		addressBookHomeSetName: func(*internal.RawXMLValue) (interface{}, error) {
+			return &addressbookHomeSet{Href: internal.Href{Path: homeSetPath}}, nil
+		},
+		internal.CurrentUserPrincipalName: func(*internal.RawXMLValue) (interface{}, error) {
+			return &internal.CurrentUserPrincipal{Href: internal.Href{Path: principalPath}}, nil
+		},
+	}
+	return internal.NewPropfindResponse(path, propfind, props)
 }
 
 func (b *backend) propfindAddressBook(propfind *internal.Propfind, ab *AddressBook) (*internal.Response, error) {
@@ -349,14 +392,6 @@ func (b *backend) propfindAddressBook(propfind *internal.Propfind, ab *AddressBo
 				},
 			}, nil
 		},
-		// TODO: this is a principal property
-		addressBookHomeSetName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &addressbookHomeSet{Href: internal.Href{Path: "/"}}, nil
-		},
-		// TODO: this should be set on all resources
-		internal.CurrentUserPrincipalName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &internal.CurrentUserPrincipal{Href: internal.Href{Path: "/"}}, nil
-		},
 	}
 
 	if ab.MaxResourceSize > 0 {
@@ -365,7 +400,7 @@ func (b *backend) propfindAddressBook(propfind *internal.Propfind, ab *AddressBo
 		}
 	}
 
-	return internal.NewPropfindResponse("/", propfind, props)
+	return internal.NewPropfindResponse(ab.Path, propfind, props)
 }
 
 func (b *backend) propfindAddressObject(propfind *internal.Propfind, ao *AddressObject) (*internal.Response, error) {
@@ -406,6 +441,14 @@ func (b *backend) Proppatch(r *http.Request, update *internal.Propertyupdate) (*
 }
 
 func (b *backend) Put(r *http.Request) (*internal.Href, error) {
+	homeSetPath, err := b.Backend.AddressbookHomeSetPath(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(r.URL.Path, homeSetPath) {
+		return nil, &internal.HTTPError{Code: http.StatusMethodNotAllowed}
+	}
+
 	if inm := r.Header.Get("If-None-Match"); inm != "" && inm != "*" {
 		return nil, internal.HTTPErrorf(http.StatusBadRequest, "invalid value for If-None-Match header")
 	}


### PR DESCRIPTION
Currently, the user principal path and the home set path are both
hardcoded to "/", for both CalDAV and CardDAV. This poses a challenge if
one wishes to run a CardDAV and CalDAV server in the same server.

This commit adds a bit plumbing to offer a convenience function,
`ServeListHomeSets`, that can serve PROPFIND responses listing both
CalDAV and CardDAV home-set properties (calendar-home-set and
addressbook-home-set respectively).

To support this, the server must be aware of the current user's
principal URL. This is not a concern of either CalDAV or CardDAV, but
WebDAV in general. This commit allows an implementation to supply this
URL through the request context. If not set, the previous convention of
using "/" remains in place.

The individual servers will continue to work as before (including the
option of keeping everything at "/"). If one wishes to run CardDAV and
CalDAV in parallel, the new `webdav.ServeListHomeSets()` can be used to
serve requests for the current user's principal URL. The request routing
is the implementation's responsibility.

For added convenience, the `ServeListHomeSets()` function includes
support for discovering the home sets via their `/.well-known` URLs.

The home set path has to be provided by the storage backend. It is
customary, though not required, that the home set path includes the
user's pricipal path. The storage backends already have access to the
request context, which allows computing the home set path based on the
pricipal path.