### PR TITLE
caldav: add supported-calendar-component-set field

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Calendar struct {
-	Path            string
-	Name            string
-	Description     string
-	MaxResourceSize int64
+	Path                  string
+	Name                  string
+	Description           string
+	MaxResourceSize       int64
+	SupportedComponentSet []string
 }
 
 type CalendarCompRequest struct {

--- a/caldav/client.go
+++ b/caldav/client.go
@@ -55,6 +55,7 @@ func (c *Client) FindCalendars(calendarHomeSet string) ([]Calendar, error) {
 		internal.DisplayNameName,
 		calendarDescriptionName,
 		maxResourceSizeName,
+		supportedCalendarComponentSetName,
 	)
 	ms, err := c.ic.Propfind(calendarHomeSet, internal.DepthOne, propfind)
 	if err != nil {
@@ -94,11 +95,22 @@ func (c *Client) FindCalendars(calendarHomeSet string) ([]Calendar, error) {
 			return nil, fmt.Errorf("carddav: max-resource-size must be a positive integer")
 		}
 
+		var supportedCompSet supportedCalendarComponentSet
+		if err := resp.DecodeProp(&supportedCompSet); err != nil && !internal.IsNotFound(err) {
+			return nil, err
+		}
+
+		compNames := make([]string, 0, len(supportedCompSet.Comp))
+		for _, comp := range supportedCompSet.Comp {
+			compNames = append(compNames, comp.Name)
+		}
+
 		l = append(l, Calendar{
-			Path:            path,
-			Name:            dispName.Name,
-			Description:     desc.Description,
-			MaxResourceSize: maxResSize.Size,
+			Path:                  path,
+			Name:                  dispName.Name,
+			Description:           desc.Description,
+			MaxResourceSize:       maxResSize.Size,
+			SupportedComponentSet: compNames,
 		})
 	}
 


### PR DESCRIPTION
Applications can detect the type of a calendar collection based on the `supported-calendar-component-set` property. This adds a respective field to the `Calendar` struct.