### PR TITLE
Allow parse etag without quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# JetBrains GoLand
+.idea
+*.iml
+*.ipr

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -342,7 +342,8 @@ type ETag string
 func (etag *ETag) UnmarshalText(b []byte) error {
 	s, err := strconv.Unquote(string(b))
 	if err != nil {
-		return fmt.Errorf("webdav: failed to unquote ETag: %v", err)
+		*etag = ETag(b)
+		return nil
 	}
 	*etag = ETag(s)
 	return nil


### PR DESCRIPTION
Catched issue same like https://github.com/emersion/go-webdav/issues/50.
Understand that it's needs when server not working strictly by RFC. But some developers will try to use library for "wrong implemented" servers and get the same error.
Think it's possible to make requirement not so strictly in that case.