### PR TITLE
carddav: return 404 if contact not found

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -134,6 +134,14 @@ func NewOKResponse(path string) *Response {
 	}
 }
 
+func NewNotFoundResponse(path string) *Response {
+	href := Href{Path: path}
+	return &Response{
+		Hrefs:  []Href{href},
+		Status: &Status{Code: http.StatusNotFound},
+	}
+}
+
 func (resp *Response) Path() (string, error) {
 	err := resp.Status.Err()
 	var path string


### PR DESCRIPTION
The backend interface is designed so that it can return `nil`, even
though no error occurred, to indicate that no contact for the given
request was found. Handle this case everywhere and return a 404, either
directly or as part of a multi-get response.