### PR TITLE
Add ServePrincipal

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -198,7 +198,7 @@ func (b *backend) Options(r *http.Request) (caps []string, allow []string, err e
 
 	var dataReq CalendarCompRequest
 	_, err = b.Backend.GetCalendarObject(r.Context(), r.URL.Path, &dataReq)
-	if httpErr, ok := err.(*internal.HTTPError); ok && httpErr.Code == http.StatusNotFound {
+	if internal.IsNotFound(err) {
 		return caps, []string{http.MethodOptions, http.MethodPut}, nil
 	} else if err != nil {
 		return nil, nil, err

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -261,10 +261,6 @@ func (b *backend) propfindCalendar(propfind *internal.Propfind, cal *Calendar) (
 				},
 			}, nil
 		},
-		// TODO: this is a principal property
-		calendarHomeSetName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &calendarHomeSet{Href: internal.Href{Path: "/"}}, nil
-		},
 		// TODO: this should be set on all resources
 		internal.CurrentUserPrincipalName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &internal.CurrentUserPrincipal{Href: internal.Href{Path: "/"}}, nil

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -14,6 +14,15 @@ import (
 
 // TODO: add support for multiple calendars
 
+// CalendarHomeSetXML returns the XML name and marshalable value for a
+// principal's calendar home set. It's designed to be used with
+// webdav.ServePrincipal.
+func CalendarHomeSetXML(path string) (xml.Name, xml.Marshaler) {
+	homeSet := &calendarHomeSet{Href: internal.Href{Path: path}}
+	v, _ := internal.EncodeRawXMLElement(homeSet)
+	return calendarHomeSetName, v
+}
+
 // Backend is a CalDAV server backend.
 type Backend interface {
 	Calendar(ctx context.Context) (*Calendar, error)

--- a/carddav/client.go
+++ b/carddav/client.go
@@ -450,11 +450,10 @@ func (c *Client) SyncCollection(path string, query *SyncQuery) (*SyncResponse, e
 	ret := &SyncResponse{SyncToken: ms.SyncToken}
 	for _, resp := range ms.Responses {
 		p, err := resp.Path()
-		if err != nil {
-			if err, ok := err.(*internal.HTTPError); ok && err.Code == http.StatusNotFound {
-				ret.Deleted = append(ret.Deleted, p)
-				continue
-			}
+		if internal.IsNotFound(err) {
+			ret.Deleted = append(ret.Deleted, p)
+			continue
+		} else if err != nil {
 			return nil, err
 		}
 

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -360,10 +360,6 @@ func (b *backend) propfindAddressBook(propfind *internal.Propfind, ab *AddressBo
 				},
 			}, nil
 		},
-		// TODO: this is a principal property
-		addressBookHomeSetName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &addressbookHomeSet{Href: internal.Href{Path: "/"}}, nil
-		},
 		// TODO: this should be set on all resources
 		internal.CurrentUserPrincipalName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &internal.CurrentUserPrincipal{Href: internal.Href{Path: "/"}}, nil

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -252,7 +252,7 @@ func (b *backend) Options(r *http.Request) (caps []string, allow []string, err e
 
 	var dataReq AddressDataRequest
 	_, err = b.Backend.GetAddressObject(r.Context(), r.URL.Path, &dataReq)
-	if httpErr, ok := err.(*internal.HTTPError); ok && httpErr.Code == http.StatusNotFound {
+	if internal.IsNotFound(err) {
 		return caps, []string{http.MethodOptions, http.MethodPut}, nil
 	} else if err != nil {
 		return nil, nil, err

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -14,6 +14,15 @@ import (
 
 // TODO: add support for multiple address books
 
+// AddressBookHomeSetXML returns the XML name and marshalable value for a
+// principal's address book home set. It's designed to be used with
+// webdav.ServePrincipal.
+func AddressBookHomeSetXML(path string) (xml.Name, xml.Marshaler) {
+	homeSet := &addressbookHomeSet{Href: internal.Href{Path: path}}
+	v, _ := internal.EncodeRawXMLElement(homeSet)
+	return addressBookHomeSetName, v
+}
+
 type PutAddressObjectOptions struct {
 	// IfNoneMatch indicates that the client does not want to overwrite
 	// an existing resource.

--- a/elements.go
+++ b/elements.go
@@ -1,0 +1,32 @@
+package webdav
+
+import (
+	"encoding/xml"
+
+	"github.com/emersion/go-webdav/internal"
+)
+
+var (
+	principalName                = xml.Name{"DAV:", "principal"}
+	principalAlternateURISetName = xml.Name{"DAV:", "alternate-URI-set"}
+	principalURLName             = xml.Name{"DAV:", "principal-URL"}
+	groupMembershipName          = xml.Name{"DAV:", "group-membership"}
+)
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.1
+type principalAlternateURISet struct {
+	XMLName xml.Name        `xml:"DAV: alternate-URI-set"`
+	Hrefs   []internal.Href `xml:"href"`
+}
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.2
+type principalURL struct {
+	XMLName xml.Name      `xml:"DAV: principal-URL"`
+	Href    internal.Href `xml:"href"`
+}
+
+// https://datatracker.ietf.org/doc/html/rfc3744#section-4.4
+type groupMembership struct {
+	XMLName xml.Name        `xml:"DAV: group-membership"`
+	Hrefs   []internal.Href `xml:"href"`
+}

--- a/internal/xml.go
+++ b/internal/xml.go
@@ -28,6 +28,9 @@ func NewRawXMLElement(name xml.Name, attr []xml.Attr, children []RawXMLValue) *R
 // EncodeRawXMLElement encodes a value into a new RawXMLValue. The XML value
 // can only be used for marshalling.
 func EncodeRawXMLElement(v interface{}) (*RawXMLValue, error) {
+	if raw, ok := v.(*RawXMLValue); ok {
+		return raw, nil
+	}
 	return &RawXMLValue{out: v}, nil
 }
 

--- a/webdav.go
+++ b/webdav.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+// Principal is a DAV principal as defined in RFC 3744 section 2.
+type Principal struct {
+	Path string
+	Name string
+}
+
 type FileInfo struct {
 	Path     string
 	Size     int64


### PR DESCRIPTION
This PR adds a `ServePrincipal` function and removes the assumption that `/` is the current user principal.

Unfortunately as-is this PR is a regression and won't be serving the CardDAV/CalDAV home sets properly anymore.