### PR TITLE
Implement GET/HEAD/PUT for calendar objects

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -297,6 +297,9 @@ func (b *backend) propfindCalendar(ctx context.Context, propfind *internal.Propf
 		internal.DisplayNameName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &internal.DisplayName{Name: cal.Name}, nil
 		},
+		calendarDescriptionName: func(*internal.RawXMLValue) (interface{}, error) {
+			return &calendarDescription{Description: cal.Description}, nil
+		},
 		supportedCalendarDataName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &supportedCalendarData{
 				Types: []calendarDataType{


### PR DESCRIPTION
Still missing a few features, but works to a certain extend. Requires an update to the backend interface to support the operations.