### PR TITLE
caldav: add missing PROPFIND features

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -344,6 +344,8 @@ func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth i
 		return nil, err
 	}
 
+	var compReq CalendarCompRequest
+
 	var resps []internal.Response
 
 	if r.URL.Path == principalPath {
@@ -365,7 +367,18 @@ func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth i
 		resps = append(resps, *resp)
 
 		if depth != internal.DepthZero {
-			// TODO
+			cos, err := b.Backend.ListCalendarObjects(r.Context(), &compReq)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, co := range cos {
+				resp, err := b.propfindCalendarObject(r.Context(), propfind, &co)
+				if err != nil {
+					return nil, err
+				}
+				resps = append(resps, *resp)
+			}
 		}
 	} else {
 		// TODO

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -381,7 +381,16 @@ func (b *backend) Propfind(r *http.Request, propfind *internal.Propfind, depth i
 			}
 		}
 	} else {
-		// TODO
+		co, err := b.Backend.GetCalendarObject(r.Context(), r.URL.Path, &compReq)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := b.propfindCalendarObject(r.Context(), propfind, co)
+		if err != nil {
+			return nil, err
+		}
+		resps = append(resps, *resp)
 	}
 
 	return internal.NewMultistatus(resps...), nil


### PR DESCRIPTION
Handle PROPFIND with depth > 0 for collection and also for calendar objects.