### PR TITLE
caldav: add support for getcontentlength property

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -117,8 +117,9 @@ type CalendarMultiGet struct {
 }
 
 type CalendarObject struct {
-	Path    string
-	ModTime time.Time
-	ETag    string
-	Data    *ical.Calendar
+	Path          string
+	ModTime       time.Time
+	ContentLength int64
+	ETag          string
+	Data          *ical.Calendar
 }

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -465,6 +465,11 @@ func (b *backend) propfindCalendarObject(ctx context.Context, propfind *internal
 		},
 	}
 
+	if co.ContentLength > 0 {
+		props[internal.GetContentLengthName] = func(*internal.RawXMLValue) (interface{}, error) {
+			return &internal.GetContentLength{Length: co.ContentLength}, nil
+		}
+	}
 	if !co.ModTime.IsZero() {
 		props[internal.GetLastModifiedName] = func(*internal.RawXMLValue) (interface{}, error) {
 			return &internal.GetLastModified{LastModified: internal.Time(co.ModTime)}, nil

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/emersion/go-ical"
@@ -321,6 +322,9 @@ func (b *backend) HeadGet(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	w.Header().Set("Content-Type", ical.MIMEType)
+	if co.ContentLength > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(co.ContentLength, 10))
+	}
 	if co.ETag != "" {
 		w.Header().Set("ETag", internal.ETag(co.ETag).String())
 	}


### PR DESCRIPTION
Allow the backend to provide a value for the `getcontentlength` property
as described in [RFC 2518 section 13.4][1].

The implementation treats is as optional, allthough it is a required
property per RFC. Most clients do perfectly fine without it, though.

Properly setting this in the backend makes the CalDAV collection
listable with clients that do require it, e.g. cadaver.

[1]: https://datatracker.ietf.org/doc/html/rfc2518#section-13.4