### PR TITLE
carddav: do property filtering in match.Filter() 

### DIFF
--- a/carddav/match_test.go
+++ b/carddav/match_test.go
@@ -64,11 +64,7 @@ END:VCARD`)
 			name: "no-limit-query",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				PropFilters: []PropFilter{
 					{
@@ -84,11 +80,7 @@ END:VCARD`)
 			name: "limit-1-query",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				Limit: 1,
 				PropFilters: []PropFilter{
@@ -105,11 +97,7 @@ END:VCARD`)
 			name: "limit-4-query",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				Limit: 4,
 				PropFilters: []PropFilter{
@@ -126,11 +114,7 @@ END:VCARD`)
 			name: "email-match",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				PropFilters: []PropFilter{
 					{
@@ -146,11 +130,7 @@ END:VCARD`)
 			name: "email-match-any",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				PropFilters: []PropFilter{
 					{
@@ -169,11 +149,7 @@ END:VCARD`)
 			name: "email-match-all",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				PropFilters: []PropFilter{{
 					Name: vcard.FieldEmail,
@@ -189,11 +165,7 @@ END:VCARD`)
 			name: "email-no-match",
 			query: &AddressBookQuery{
 				DataRequest: AddressDataRequest{
-					Props: []string{
-						vcard.FieldFormattedName,
-						vcard.FieldEmail,
-						vcard.FieldUID,
-					},
+					AllProp: true,
 				},
 				PropFilters: []PropFilter{
 					{

--- a/carddav/match_test.go
+++ b/carddav/match_test.go
@@ -46,6 +46,11 @@ N:Gopher;Carla;;;
 EMAIL;PID=1.1:carla@example.com
 CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0553
 END:VCARD`)
+	carlaFiltered := newAO(`BEGIN:VCARD
+VERSION:4.0
+UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b3
+EMAIL;PID=1.1:carla@example.com
+END:VCARD`)
 
 	for _, tc := range []struct {
 		name  string
@@ -176,6 +181,45 @@ END:VCARD`)
 			},
 			addrs: []AddressObject{alice, bob, carla},
 			want:  []AddressObject{},
+		},
+		{
+			name: "email-match-filter-properties",
+			query: &AddressBookQuery{
+				DataRequest: AddressDataRequest{
+					Props: []string{
+						vcard.FieldVersion,
+						vcard.FieldUID,
+						vcard.FieldEmail,
+					},
+				},
+				PropFilters: []PropFilter{
+					{
+						Name:        vcard.FieldEmail,
+						TextMatches: []TextMatch{{Text: "carla"}},
+					},
+				},
+			},
+			addrs: []AddressObject{alice, bob, carla},
+			want:  []AddressObject{carlaFiltered},
+		},
+		{
+			name: "email-match-filter-properties-always-returns-version",
+			query: &AddressBookQuery{
+				DataRequest: AddressDataRequest{
+					Props: []string{
+						vcard.FieldUID,
+						vcard.FieldEmail,
+					},
+				},
+				PropFilters: []PropFilter{
+					{
+						Name:        vcard.FieldEmail,
+						TextMatches: []TextMatch{{Text: "carla"}},
+					},
+				},
+			},
+			addrs: []AddressObject{alice, bob, carla},
+			want:  []AddressObject{carlaFiltered},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
I am a bit unsure whether or not this makes sense and would like to solicit your input :slightly_smiling_face: 

I would say that this implementation makes the behavior of the `Filter()` function more correct. However, a case could be made that this performs work that e.g. backend may have already performed. Example: a hypothetical database backend might construct a database query that already returns the objects reduced to the requested properties (and/or only those matching the query). In this case, the current implementation would simply create a copy of each object with no further benefit.

However, I would argue that that is a very advanced use case, and such a backend would probably not be using the `Filter()` function in the first place. Also, while I could imagine such a hypothetical backend for carddav, the situation for caldav is much more complex (recursive data structures), and I think having a correct reference implementation at all would very much outweigh the performance considerations here.

Let me know how you feel about this. Also, regardless of outcome, the first commit should be merged, but I am happy to create another PR for that if we decide that this is not fit.