### PR TITLE
client: support redirects in FindCurrentUserPrincipal

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -149,7 +149,11 @@ func (c *Client) PropfindFlat(path string, propfind *Propfind) (*Response, error
 		return nil, err
 	}
 
-	return ms.Get(c.ResolveHref(path).Path)
+	// If the client followed a redirect, the Href might be different from the request path
+	if len(ms.Responses) != 1 {
+		return nil, fmt.Errorf("PROPFIND with Depth: 0 returned %d responses", len(ms.Responses))
+	}
+	return &ms.Responses[0], nil
 }
 
 func parseCommaSeparatedSet(values []string, upper bool) map[string]bool {


### PR DESCRIPTION
One method to find the current user principal URL is to request the
`/.well-known/carddav` URL (see [RFC 6764, section 6][1]).

Add this as second attempt if the discovery via the configured endpoint
fails. This helps the client discover resources even if just given an
endpoint without path.

[1]: https://datatracker.ietf.org/doc/html/rfc6764#section-6