### PR TITLE
carddav/caldav: use 308 for .well-known redirects

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -58,7 +58,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Redirect(w, r, principalPath, http.StatusMovedPermanently)
+		http.Redirect(w, r, principalPath, http.StatusPermanentRedirect)
 		return
 	}
 

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -57,7 +57,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Redirect(w, r, principalPath, http.StatusMovedPermanently)
+		http.Redirect(w, r, principalPath, http.StatusPermanentRedirect)
 		return
 	}
 


### PR DESCRIPTION
This makes it a little less ambiguous (and, in case of Go clients, a lot
easier) that clients should follow the redirect by sending the same
PROPFIND request, including body, to the new location.

See also the documentation of [http.Client.Do()][1] and the comments in
[http.redirectBehavior()][2].

Confirmed to not make a difference for Evolution and Thunderbird
clients.

[1]: https://pkg.go.dev/net/http#Client.Do
[2]: https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/http/client.go;drc=d8762b2f4532cc2e5ec539670b88bbc469a13938;l=502