### PR TITLE
caldav: add Content-Length support to client

### DIFF
--- a/caldav/client.go
+++ b/caldav/client.go
@@ -191,6 +191,11 @@ func decodeCalendarObjectList(ms *internal.Multistatus) ([]CalendarObject, error
 			return nil, err
 		}
 
+		var getContentLength internal.GetContentLength
+		if err := resp.DecodeProp(&getContentLength); err != nil && !internal.IsNotFound(err) {
+			return nil, err
+		}
+
 		r := bytes.NewReader(calData.Data)
 		data, err := ical.NewDecoder(r).Decode()
 		if err != nil {
@@ -198,10 +203,11 @@ func decodeCalendarObjectList(ms *internal.Multistatus) ([]CalendarObject, error
 		}
 
 		addrs = append(addrs, CalendarObject{
-			Path:    path,
-			ModTime: time.Time(getLastMod.LastModified),
-			ETag:    string(getETag.ETag),
-			Data:    data,
+			Path:          path,
+			ModTime:       time.Time(getLastMod.LastModified),
+			ContentLength: getContentLength.Length,
+			ETag:          string(getETag.ETag),
+			Data:          data,
 		})
 	}
 
@@ -276,6 +282,13 @@ func populateCalendarObject(co *CalendarObject, resp *http.Response) error {
 			return err
 		}
 		co.ETag = etag
+	}
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		n, err := strconv.ParseInt(contentLength, 10, 64)
+		if err != nil {
+			return err
+		}
+		co.ContentLength = n
 	}
 	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
 		t, err := http.ParseTime(lastModified)


### PR DESCRIPTION
Follow-up for https://github.com/emersion/go-webdav/pull/83.

cc @bitfehler 