### PR TITLE
internal: fix XML element struct naming

### DIFF
--- a/caldav/client.go
+++ b/caldav/client.go
@@ -35,8 +35,8 @@ func NewClient(c webdav.HTTPClient, endpoint string) (*Client, error) {
 }
 
 func (c *Client) FindCalendarHomeSet(principal string) (string, error) {
-	propfind := internal.NewPropNamePropfind(calendarHomeSetName)
-	resp, err := c.ic.PropfindFlat(principal, propfind)
+	propfind := internal.NewPropNamePropFind(calendarHomeSetName)
+	resp, err := c.ic.PropFindFlat(principal, propfind)
 	if err != nil {
 		return "", err
 	}
@@ -50,14 +50,14 @@ func (c *Client) FindCalendarHomeSet(principal string) (string, error) {
 }
 
 func (c *Client) FindCalendars(calendarHomeSet string) ([]Calendar, error) {
-	propfind := internal.NewPropNamePropfind(
+	propfind := internal.NewPropNamePropFind(
 		internal.ResourceTypeName,
 		internal.DisplayNameName,
 		calendarDescriptionName,
 		maxResourceSizeName,
 		supportedCalendarComponentSetName,
 	)
-	ms, err := c.ic.Propfind(calendarHomeSet, internal.DepthOne, propfind)
+	ms, err := c.ic.PropFind(calendarHomeSet, internal.DepthOne, propfind)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func encodeCompFilter(filter *CompFilter) *compFilter {
 	return &encoded
 }
 
-func decodeCalendarObjectList(ms *internal.Multistatus) ([]CalendarObject, error) {
+func decodeCalendarObjectList(ms *internal.MultiStatus) ([]CalendarObject, error) {
 	addrs := make([]CalendarObject, 0, len(ms.Responses))
 	for _, resp := range ms.Responses {
 		path, err := resp.Path()

--- a/carddav/client.go
+++ b/carddav/client.go
@@ -81,8 +81,8 @@ func (c *Client) HasSupport() error {
 }
 
 func (c *Client) FindAddressBookHomeSet(principal string) (string, error) {
-	propfind := internal.NewPropNamePropfind(addressBookHomeSetName)
-	resp, err := c.ic.PropfindFlat(principal, propfind)
+	propfind := internal.NewPropNamePropFind(addressBookHomeSetName)
+	resp, err := c.ic.PropFindFlat(principal, propfind)
 	if err != nil {
 		return "", err
 	}
@@ -104,14 +104,14 @@ func decodeSupportedAddressData(supported *supportedAddressData) []AddressDataTy
 }
 
 func (c *Client) FindAddressBooks(addressBookHomeSet string) ([]AddressBook, error) {
-	propfind := internal.NewPropNamePropfind(
+	propfind := internal.NewPropNamePropFind(
 		internal.ResourceTypeName,
 		internal.DisplayNameName,
 		addressBookDescriptionName,
 		maxResourceSizeName,
 		supportedAddressDataName,
 	)
-	ms, err := c.ic.Propfind(addressBookHomeSet, internal.DepthOne, propfind)
+	ms, err := c.ic.PropFind(addressBookHomeSet, internal.DepthOne, propfind)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func encodeTextMatch(tm *TextMatch) *textMatch {
 	}
 }
 
-func decodeAddressList(ms *internal.Multistatus) ([]AddressObject, error) {
+func decodeAddressList(ms *internal.MultiStatus) ([]AddressObject, error) {
 	addrs := make([]AddressObject, 0, len(ms.Responses))
 	for _, resp := range ms.Responses {
 		path, err := resp.Path()

--- a/client.go
+++ b/client.go
@@ -48,11 +48,11 @@ func NewClient(c HTTPClient, endpoint string) (*Client, error) {
 }
 
 func (c *Client) FindCurrentUserPrincipal() (string, error) {
-	propfind := internal.NewPropNamePropfind(internal.CurrentUserPrincipalName)
+	propfind := internal.NewPropNamePropFind(internal.CurrentUserPrincipalName)
 
 	// TODO: consider retrying on the root URI "/" if this fails, as suggested
 	// by the RFC?
-	resp, err := c.ic.PropfindFlat("", propfind)
+	resp, err := c.ic.PropFindFlat("", propfind)
 	if err != nil {
 		return "", err
 	}
@@ -68,7 +68,7 @@ func (c *Client) FindCurrentUserPrincipal() (string, error) {
 	return prop.Href.Path, nil
 }
 
-var fileInfoPropfind = internal.NewPropNamePropfind(
+var fileInfoPropFind = internal.NewPropNamePropFind(
 	internal.ResourceTypeName,
 	internal.GetContentLengthName,
 	internal.GetLastModifiedName,
@@ -122,7 +122,7 @@ func fileInfoFromResponse(resp *internal.Response) (*FileInfo, error) {
 }
 
 func (c *Client) Stat(name string) (*FileInfo, error) {
-	resp, err := c.ic.PropfindFlat(name, fileInfoPropfind)
+	resp, err := c.ic.PropFindFlat(name, fileInfoPropFind)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (c *Client) Readdir(name string, recursive bool) ([]FileInfo, error) {
 		depth = internal.DepthInfinity
 	}
 
-	ms, err := c.ic.Propfind(name, depth, fileInfoPropfind)
+	ms, err := c.ic.PropFind(name, depth, fileInfoPropFind)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -111,7 +111,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (c *Client) DoMultiStatus(req *http.Request) (*Multistatus, error) {
+func (c *Client) DoMultiStatus(req *http.Request) (*MultiStatus, error) {
 	resp, err := c.Do(req)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (c *Client) DoMultiStatus(req *http.Request) (*Multistatus, error) {
 	}
 
 	// TODO: the response can be quite large, support streaming Response elements
-	var ms Multistatus
+	var ms MultiStatus
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (c *Client) DoMultiStatus(req *http.Request) (*Multistatus, error) {
 	return &ms, nil
 }
 
-func (c *Client) Propfind(path string, depth Depth, propfind *Propfind) (*Multistatus, error) {
+func (c *Client) PropFind(path string, depth Depth, propfind *PropFind) (*MultiStatus, error) {
 	req, err := c.NewXMLRequest("PROPFIND", path, propfind)
 	if err != nil {
 		return nil, err
@@ -143,8 +143,8 @@ func (c *Client) Propfind(path string, depth Depth, propfind *Propfind) (*Multis
 }
 
 // PropfindFlat performs a PROPFIND request with a zero depth.
-func (c *Client) PropfindFlat(path string, propfind *Propfind) (*Response, error) {
-	ms, err := c.Propfind(path, DepthZero, propfind)
+func (c *Client) PropFindFlat(path string, propfind *PropFind) (*Response, error) {
+	ms, err := c.PropFind(path, DepthZero, propfind)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (c *Client) Options(path string) (classes map[string]bool, methods map[stri
 }
 
 // SyncCollection perform a `sync-collection` REPORT operation on a resource
-func (c *Client) SyncCollection(path, syncToken string, level Depth, limit *Limit, prop *Prop) (*Multistatus, error) {
+func (c *Client) SyncCollection(path, syncToken string, level Depth, limit *Limit, prop *Prop) (*MultiStatus, error) {
 	q := SyncCollectionQuery{
 		SyncToken: syncToken,
 		SyncLevel: level.String(),

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -89,22 +89,22 @@ func (h *Href) UnmarshalText(b []byte) error {
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.16
-type Multistatus struct {
+type MultiStatus struct {
 	XMLName             xml.Name   `xml:"DAV: multistatus"`
 	Responses           []Response `xml:"response"`
 	ResponseDescription string     `xml:"responsedescription,omitempty"`
 	SyncToken           string     `xml:"sync-token,omitempty"`
 }
 
-func NewMultistatus(resps ...Response) *Multistatus {
-	return &Multistatus{Responses: resps}
+func NewMultiStatus(resps ...Response) *MultiStatus {
+	return &MultiStatus{Responses: resps}
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.24
 type Response struct {
 	XMLName             xml.Name   `xml:"DAV: response"`
 	Hrefs               []Href     `xml:"href"`
-	Propstats           []Propstat `xml:"propstat,omitempty"`
+	PropStats           []PropStat `xml:"propstat,omitempty"`
 	ResponseDescription string     `xml:"responsedescription,omitempty"`
 	Status              *Status    `xml:"status,omitempty"`
 	Error               *Error     `xml:"error,omitempty"`
@@ -179,7 +179,7 @@ func (resp *Response) DecodeProp(values ...interface{}) error {
 		if err := resp.Err(); err != nil {
 			return newPropError(name, err)
 		}
-		for _, propstat := range resp.Propstats {
+		for _, propstat := range resp.PropStats {
 			raw := propstat.Prop.Get(name)
 			if raw == nil {
 				continue
@@ -211,15 +211,15 @@ func (resp *Response) EncodeProp(code int, v interface{}) error {
 		return err
 	}
 
-	for i := range resp.Propstats {
-		propstat := &resp.Propstats[i]
+	for i := range resp.PropStats {
+		propstat := &resp.PropStats[i]
 		if propstat.Status.Code == code {
 			propstat.Prop.Raw = append(propstat.Prop.Raw, *raw)
 			return nil
 		}
 	}
 
-	resp.Propstats = append(resp.Propstats, Propstat{
+	resp.PropStats = append(resp.PropStats, PropStat{
 		Status: Status{Code: code},
 		Prop:   Prop{Raw: []RawXMLValue{*raw}},
 	})
@@ -233,7 +233,7 @@ type Location struct {
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.22
-type Propstat struct {
+type PropStat struct {
 	XMLName             xml.Name `xml:"DAV: propstat"`
 	Prop                Prop     `xml:"prop"`
 	Status              Status   `xml:"status"`
@@ -284,7 +284,7 @@ func (p *Prop) Decode(v interface{}) error {
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.20
-type Propfind struct {
+type PropFind struct {
 	XMLName  xml.Name  `xml:"DAV: propfind"`
 	Prop     *Prop     `xml:"prop,omitempty"`
 	AllProp  *struct{} `xml:"allprop,omitempty"`
@@ -300,8 +300,8 @@ func xmlNamesToRaw(names []xml.Name) []RawXMLValue {
 	return l
 }
 
-func NewPropNamePropfind(names ...xml.Name) *Propfind {
-	return &Propfind{Prop: &Prop{Raw: xmlNamesToRaw(names)}}
+func NewPropNamePropFind(names ...xml.Name) *PropFind {
+	return &PropFind{Prop: &Prop{Raw: xmlNamesToRaw(names)}}
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.8
@@ -329,7 +329,7 @@ func (t *ResourceType) Is(name xml.Name) bool {
 	return false
 }
 
-var CollectionName = xml.Name{"DAV:", "collection"}
+var CollectionName = xml.Name{Namespace, "collection"}
 
 // https://tools.ietf.org/html/rfc4918#section-15.4
 type GetContentLength struct {
@@ -415,7 +415,7 @@ type CurrentUserPrincipal struct {
 }
 
 // https://tools.ietf.org/html/rfc4918#section-14.19
-type Propertyupdate struct {
+type PropertyUpdate struct {
 	XMLName xml.Name `xml:"DAV: propertyupdate"`
 	Remove  []Remove `xml:"remove"`
 	Set     []Set    `xml:"set"`

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -20,7 +20,7 @@ const exampleDeleteMultistatusStr = `<?xml version="1.0" encoding="utf-8" ?>
 
 func TestResponse_Err_error(t *testing.T) {
 	r := strings.NewReader(exampleDeleteMultistatusStr)
-	var ms Multistatus
+	var ms MultiStatus
 	if err := xml.NewDecoder(r).Decode(&ms); err != nil {
 		t.Fatalf("Decode() = %v", err)
 	}


### PR DESCRIPTION
This has been bugging me for a while. We were sometimes using TitleCase, sometimes Lowercase. Let's align on the idiomatic Go naming and pick TitleCase everywhere.

cc @bitfehler 