### PR TITLE
fix: Response body was not closed causing the goroutine leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -193,8 +193,13 @@ func (c *Client) Create(name string) (io.WriteCloser, error) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := c.ic.Do(req)
-		done <- err
+		resp, err := c.ic.Do(req)
+		if err != nil {
+			done <- err
+			return
+		}
+		resp.Body.Close()
+		done <- nil
 	}()
 
 	return &fileWriter{pw, done}, nil
@@ -206,8 +211,12 @@ func (c *Client) RemoveAll(name string) error {
 		return err
 	}
 
-	_, err = c.ic.Do(req)
-	return err
+	resp, err := c.ic.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func (c *Client) Mkdir(name string) error {
@@ -216,8 +225,12 @@ func (c *Client) Mkdir(name string) error {
 		return err
 	}
 
-	_, err = c.ic.Do(req)
-	return err
+	resp, err := c.ic.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func (c *Client) CopyAll(name, dest string, overwrite bool) error {
@@ -229,8 +242,12 @@ func (c *Client) CopyAll(name, dest string, overwrite bool) error {
 	req.Header.Set("Destination", c.ic.ResolveHref(dest).String())
 	req.Header.Set("Overwrite", internal.FormatOverwrite(overwrite))
 
-	_, err = c.ic.Do(req)
-	return err
+	resp, err := c.ic.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func (c *Client) MoveAll(name, dest string, overwrite bool) error {
@@ -242,6 +259,10 @@ func (c *Client) MoveAll(name, dest string, overwrite bool) error {
 	req.Header.Set("Destination", c.ic.ResolveHref(dest).String())
 	req.Header.Set("Overwrite", internal.FormatOverwrite(overwrite))
 
-	_, err = c.ic.Do(req)
-	return err
+	resp, err := c.ic.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }


### PR DESCRIPTION

Using webdav in [juicefs server](https://github.com/juicedata/juicefs) gives the error 'too many open files'

```bash
(pprof) top
Showing nodes accounting for 643, 99.69% of 645 total
Dropped 76 nodes (cum <= 3)
Showing top 10 nodes out of 46
      flat  flat%   sum%        cum   cum%
       640 99.22% 99.22%        640 99.22%  runtime.gopark
         3  0.47% 99.69%          3  0.47%  syscall.Syscall
         0     0% 99.69%         20  3.10%  bufio.(*Reader).Peek
         0     0% 99.69%         21  3.26%  bufio.(*Reader).fill
         0     0% 99.69%         20  3.10%  github.com/emersion/go-webdav.(*Client).Create.func1
         0     0% 99.69%         20  3.10%  github.com/emersion/go-webdav.(*fileWriter).Close
         0     0% 99.69%         20  3.10%  github.com/emersion/go-webdav/internal.(*Client).Do
         0     0% 99.69%         20  3.10%  github.com/juicedata/juicefs/pkg/chunk.(*cachedStore).put
         0     0% 99.69%         20  3.10%  github.com/juicedata/juicefs/pkg/chunk.(*cachedStore).put.func1
         0     0% 99.69%         20  3.10%  github.com/juicedata/juicefs/pkg/chunk.(*cachedStore).upload
```