### PR TITLE
carddav: use "/.well-known/carddav/" as initial context path in Discover

### DIFF
--- a/carddav/client.go
+++ b/carddav/client.go
@@ -46,6 +46,7 @@ func Discover(domain string) (string, error) {
 	} else {
 		u.Host = fmt.Sprintf("%v:%v", target, addr.Port)
 	}
+	u.Path = "/.well-known/carddav"
 	return u.String(), nil
 }
 


### PR DESCRIPTION
See RFC 6764 section 6 item 3.