### PR TITLE
carddav: evaluate recurrence in match helper 

### DIFF
--- a/caldav/match.go
+++ b/caldav/match.go
@@ -127,9 +127,19 @@ func matchPropFilter(filter PropFilter, comp *ical.Component) (bool, error) {
 func matchCompTimeRange(start, end time.Time, comp *ical.Component) (bool, error) {
 	// See https://datatracker.ietf.org/doc/html/rfc4791#section-9.9
 
-	// TODO handle "infinity" values in query
-	// TODO handle recurring events
+	// evaluate recurring components
+	rset, err := comp.RecurrenceSet(start.Location())
+	if err != nil {
+		return false, err
+	}
+	if rset != nil {
+		// TODO we can only set inclusive to true or false, but really the
+		// start time is inclusive while the end time is not :/
+		return len(rset.Between(start, end, true)) > 0, nil
+	}
 
+	// TODO handle "infinity" values in query
+	// TODO handle more than just events
 	if comp.Name != ical.CompEvent {
 		return false, nil
 	}

--- a/caldav/match_test.go
+++ b/caldav/match_test.go
@@ -253,6 +253,24 @@ END:VCALENDAR`)
 			addrs: []CalendarObject{event1, event2, event3, todo1},
 			want:  []CalendarObject{event1},
 		},
+		{
+			// Query a time range that only returns a result if recurrence is properly evaluated.
+			name: "recurring events in time range",
+			query: &CalendarQuery{
+				CompFilter: CompFilter{
+					Name: "VCALENDAR",
+					Comps: []CompFilter{
+						CompFilter{
+							Name:  "VEVENT",
+							Start: toDate(t, "20060103T000000Z"),
+							End:   toDate(t, "20060104T000000Z"),
+						},
+					},
+				},
+			},
+			addrs: []CalendarObject{event1, event2, event3, todo1},
+			want:  []CalendarObject{event2},
+		},
 		// TODO add more examples
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/emersion/go-webdav
 go 1.13
 
 require (
-	github.com/emersion/go-ical v0.0.0-20200224201310-cd514449c39e
+	github.com/emersion/go-ical v0.0.0-20220601085725-0864dccc089f
 	github.com/emersion/go-vcard v0.0.0-20191221110513-5f81fa0d3cc7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/emersion/go-ical v0.0.0-20200224201310-cd514449c39e h1:YGM1sI7edZOt8KAfX9Miq/X99d2QXdgjkJ7vN4HjxAA=
-github.com/emersion/go-ical v0.0.0-20200224201310-cd514449c39e/go.mod h1:4xVTBPcT43a1pp3vdaa+FuRdX5XhKCZPpWv7m0z9ByM=
+github.com/emersion/go-ical v0.0.0-20220601085725-0864dccc089f h1:feGUUxxvOtWVOhTko8Cbmp33a+tU0IMZxMEmnkoAISQ=
+github.com/emersion/go-ical v0.0.0-20220601085725-0864dccc089f/go.mod h1:2MKFUgfNMULRxqZkadG1Vh44we3y5gJAtTBlVsx1BKQ=
 github.com/emersion/go-vcard v0.0.0-20191221110513-5f81fa0d3cc7 h1:SE+tcd+0kn0cT4MqTo66gmkjqWHF1Z+Yha5/rhLs/H8=
 github.com/emersion/go-vcard v0.0.0-20191221110513-5f81fa0d3cc7/go.mod h1:HMJKR5wlh/ziNp+sHEDV2ltblO4JD2+IdDOWtGcQBTM=
+github.com/teambition/rrule-go v1.7.2 h1:goEajFWYydfCgavn2m/3w5U+1b3PGqPUHx/fFSVfTy0=
+github.com/teambition/rrule-go v1.7.2/go.mod h1:mBJ1Ht5uboJ6jexKdNUJg2NcwP8uUMNvStWXlJD3MvU=


### PR DESCRIPTION
The match helper will now properly return recurring events if any of
their recurrences fall into the queried time range. A test for this was
added as well.

This requires bumping the go-ical version the go-webdav depends on, which pulls in github.com/teambition/rrule-go as a dependency.