### PR TITLE
caldav: fix validation error when VTIMEZONE is after VEVENT

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -54,7 +54,7 @@ func ValidateCalendarObject(cal *ical.Calendar) (eventType string, uid string, e
 		if uid == "" {
 			uid = compUID
 		}
-		if uid != compUID {
+		if compUID != "" && uid != compUID {
 			return "", "", fmt.Errorf("conflicting UID values in calendar: %s, %s", uid, compUID)
 		}
 	}


### PR DESCRIPTION
If in a calendar file VTIMEZONE component is after VEVENT then on the second pass of the `comp` loop `uid` is not blank (set from VEVENT) but `compUID` is blank (set from VTIMEZONE). This wrongly causes error `conflicting UID values in calendar`.