### PR TITLE
caldav: use same static path layout as carddav

### DIFF
--- a/carddav/carddav_test.go
+++ b/carddav/carddav_test.go
@@ -27,9 +27,9 @@ CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0551
 END:VCARD`
 	alicePath = "urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1.vcf"
 
-	currentUserPrincipalKey = "test:currentUserPrincipal"
-	homeSetPathKey          = "test:homeSetPath"
-	addressBookPathKey      = "test:addressBookPath"
+	currentUserPrincipalKey = contextKey("test:currentUserPrincipal")
+	homeSetPathKey          = contextKey("test:homeSetPath")
+	addressBookPathKey      = contextKey("test:addressBookPath")
 )
 
 func (*testBackend) CurrentUserPrincipal(ctx context.Context) (string, error) {


### PR DESCRIPTION
This is like #101 but for CalDAV.

There might be some opportunities for shared code, but the devil is in the details. I'd like to wait for support for multiple calendars/address books - it will be fairly easy now, and after that there should be no more big changes. Then I am happy to give it a once-over with regards to code sharing.

Also adds tests similar to the CardDAV ones.