### PR TITLE
Support setting capabilities in ServePrincipal()

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -12,6 +12,8 @@ import (
 	"github.com/emersion/go-webdav/internal"
 )
 
+var CapabilityCalendar = webdav.Capability("calendar-access")
+
 func NewCalendarHomeSet(path string) webdav.BackendSuppliedHomeSet {
 	return &calendarHomeSet{Href: internal.Href{Path: path}}
 }

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -11,6 +11,8 @@ import (
 	"github.com/emersion/go-webdav/internal"
 )
 
+var CapabilityAddressBook = webdav.Capability("addressbook")
+
 func NewAddressBookHomeSet(path string) webdav.BackendSuppliedHomeSet {
 	return &addressbookHomeSet{Href: internal.Href{Path: path}}
 }

--- a/server.go
+++ b/server.go
@@ -261,9 +261,12 @@ type UserPrincipalBackend interface {
 	CurrentUserPrincipal(ctx context.Context) (string, error)
 }
 
+type Capability string
+
 type ServePrincipalOptions struct {
 	CurrentUserPrincipalPath string
 	HomeSets                 []BackendSuppliedHomeSet
+	Capabilities             []Capability
 }
 
 // ServePrincipal replies to requests for a principal URL.
@@ -271,7 +274,10 @@ func ServePrincipal(w http.ResponseWriter, r *http.Request, options *ServePrinci
 	switch r.Method {
 	case http.MethodOptions:
 		caps := []string{"1", "3"}
-		allow := []string{http.MethodOptions, "PROPFIND"}
+		for _, c := range options.Capabilities {
+			caps = append(caps, string(c))
+		}
+		allow := []string{http.MethodOptions, "PROPFIND", "REPORT", "DELETE", "MKCOL"}
 		w.Header().Add("DAV", strings.Join(caps, ", "))
 		w.Header().Add("Allow", strings.Join(allow, ", "))
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
This is done properly in the carddav and caldav packages, but the custom function does not know what the user intends to serve, so it must be passed in from the user. Without this, certain clients (e.g. DAVx5) will be unable to discover endpoints served this way.

Also slightly extend the supported methods returned on OPTIONS requests. REPORT is properly supported, the others are mostly for not giving clients the impression that the resources are read-only.