### PR TITLE
Allow PROPFIND request with empty request body

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -131,8 +131,13 @@ func (h *Handler) handleOptions(w http.ResponseWriter, r *http.Request) error {
 
 func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) error {
 	var propfind PropFind
-	if err := DecodeXMLRequest(r, &propfind); err != nil {
-		return err
+	
+	if r.ContentLength == 0 {
+		propfind.AllProp = &struct{}{}
+	} else {
+		if err := DecodeXMLRequest(r, &propfind); err != nil {
+			return err
+		}
 	}
 
 	depth := DepthInfinity


### PR DESCRIPTION
A request body is not mandatory in PROPFIND request according to https://www.rfc-editor.org/rfc/rfc4918#section-9.1
If the client does not send a request body, the request should be treated as an AllProp request.