### PR TITLE
Make sure to handle a PROPFIND to `/`

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -371,6 +371,16 @@ func (b *backend) PropFind(r *http.Request, propfind *internal.PropFind, depth i
 	var resps []internal.Response
 
 	switch resType {
+	case resourceTypeRoot:
+		_, err := b.Backend.CurrentUserPrincipal(r.Context())
+		if err != nil {
+			return nil, err
+		}
+		resp, err := b.propFindUserPrincipal(r.Context(), propfind)
+		if err != nil {
+			return nil, err
+		}
+		resps = append(resps, *resp)
 	case resourceTypeUserPrincipal:
 		principalPath, err := b.Backend.CurrentUserPrincipal(r.Context())
 		if err != nil {

--- a/caldav/server_test.go
+++ b/caldav/server_test.go
@@ -61,7 +61,7 @@ var propFindUserPrincipal = `
 </A:propfind>
 `
 
-func TestPropFindCurrentUserPrincipal(t *testing.T) {
+func TestPropFindRoot(t *testing.T) {
 	req := httptest.NewRequest("PROPFIND", "/", strings.NewReader(propFindUserPrincipal))
 	req.Header.Set("Content-Type", "application/xml")
 	w := httptest.NewRecorder()


### PR DESCRIPTION
It seems like the Reminders app in `iOS`/`macOS` does this request as the first thing when setting up an account, so it seems reasonable to handle it for us.

This just returns the most basic current-user-principal now, but that should hopefully be enough to continue the process.
