### PR TITLE
fix: escape href url before parsing

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -80,7 +80,8 @@ func (h *Href) MarshalText() ([]byte, error) {
 }
 
 func (h *Href) UnmarshalText(b []byte) error {
-	u, err := url.Parse(string(b))
+	pathEscBytes := url.PathEscape(string(b))
+	u, err := url.Parse(pathEscBytes)
 	if err != nil {
 		return err
 	}

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -63,3 +63,19 @@ func TestTimeRoundTrip(t *testing.T) {
 		t.Fatalf("invalid round-trip:\ngot= %s\nwant=%s", got, want)
 	}
 }
+
+func TestHrefUnmarshalText(t *testing.T) {
+       expectedURI := "/caldav/john.doe@example.com/calendar/test.ics"
+
+       var got Href
+       err := got.UnmarshalText([]byte(expectedURI))
+       if err != nil {
+               t.Fatalf("UnmarshalText failed for URI: %+v", err)
+       }
+
+       unexpectedURI := "/caldav/john.doe@example.com/calendar/abc%eth0.ics"
+       err = got.UnmarshalText([]byte(unexpectedURI))
+       if err != nil {
+               t.Fatalf("UnmarshalText failed for URI: %+v", err)
+       }
+}


### PR DESCRIPTION
Thank you for providing this library here for free. I really appreciate it because it helps me to write a new app.

I encountered a weird bug while parsing an ics uri from a caldav webserver which probably makes a few few non-standard naming choices here and there :smile: 

In any case, this server decided to include a `%` in the uri which was parsed in the `Href.UnmarshalText` function. This led to the following error message:

```bash
go test
--- FAIL: TestUnmarshalText (0.00s)
    elements_test.go:80: UnmarshalText failed for URI: parse "/caldav/john.doe@example.com/calendar/abc%eth0.ics": invalid URL escape "%et"
FAIL
exit status 1
FAIL    github.com/emersion/go-webdav/internal  0.009s
```

With this patch, the uri string is first escaped with [`url.PathEscape`](https://pkg.go.dev/net/url#PathEscape) before being parsed with [`url.Parse`](https://pkg.go.dev/net/url#Parse).

The problematic sequence of characters (`%et`, which is not a recognized url escaping sequence) gets translated into `%25et` that can be parsed without issues.