### PR TITLE
fix: check etag quotes before unquote

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -374,11 +374,16 @@ type GetETag struct {
 type ETag string
 
 func (etag *ETag) UnmarshalText(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return fmt.Errorf("webdav: failed to unquote ETag: %v", err)
+	s := string(b)
+	if (s[0:1] == "\"") {
+		sUnquoted, err := strconv.Unquote(s)
+		if err != nil {
+			return fmt.Errorf("webdav: failed to unquote ETag: %v", err)
+		}
+		*etag = ETag(sUnquoted)
+	} else {
+		*etag = ETag(s)
 	}
-	*etag = ETag(s)
 	return nil
 }
 

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -63,3 +63,19 @@ func TestTimeRoundTrip(t *testing.T) {
 		t.Fatalf("invalid round-trip:\ngot= %s\nwant=%s", got, want)
 	}
 }
+
+func TestETagUnmarshalText(t *testing.T) {
+	quotedEtag := `"123"`
+
+	var got ETag
+	err := got.UnmarshalText([]byte(quotedEtag))
+	if err != nil {
+		t.Fatalf("UnmarshalText failed for ETag: %+v", err)
+	}
+
+	unquotedEtag := "123"
+	err = got.UnmarshalText([]byte(unquotedEtag))
+	if err != nil {
+		t.Fatalf("UnmarshalText failed for ETag: %+v", err)
+	}
+}


### PR DESCRIPTION
I encountered the same issue with non-standard (unquoted) etags from my caldav server as my predecessors:
* https://github.com/emersion/go-webdav/issues/50
* https://github.com/emersion/go-webdav/pull/69

```bash
go test
--- FAIL: TestETagUnmarshalText (0.00s)
    elements_test.go:79: UnmarshalText failed for ETag: webdav: failed to unquote ETag: invalid syntax
FAIL
exit status 1
FAIL    github.com/emersion/go-webdav/internal  0.006s
```

This patch will check the etag first, before calling the [`strconv.Unquote`](https://pkg.go.dev/strconv#Unquote) function. A string without quotes will not be unquoted.