### PR TITLE
Patch to not fail when eTag not present

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -374,6 +374,10 @@ type GetETag struct {
 type ETag string
 
 func (etag *ETag) UnmarshalText(b []byte) error {
+	if len(b) == 0 { // some servers return "" for eTag
+		return nil
+	}
+
 	s, err := strconv.Unquote(string(b))
 	if err != nil {
 		return fmt.Errorf("webdav: failed to unquote ETag: %v", err)


### PR DESCRIPTION
Feel free to close if this is not RFC-compliant. The server I am interacting with doesn't provide an eTag.