### PR TITLE
internal: fix always-true interface comparison

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -143,7 +143,10 @@ func (resp *Response) Err() error {
 		return nil
 	}
 
-	var err error = resp.Error
+	var err error
+	if resp.Error != nil {
+		err = resp.Error
+	}
 	if resp.ResponseDescription != "" {
 		if err != nil {
 			err = fmt.Errorf("%v (%w)", resp.ResponseDescription, err)


### PR DESCRIPTION
This CL corrects the following bug uncovered by staticcheck:

```
  internal/elements.go:148:6: this comparison is always true (SA4023)
    internal/elements.go:146:18: the lhs of the comparison gets its value from here and has a concrete type
```