### PR TITLE
caldav: add path to interface QueryCalendarObjects

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -34,7 +34,7 @@ type Backend interface {
 	GetCalendar(ctx context.Context, path string) (*Calendar, error)
 	GetCalendarObject(ctx context.Context, path string, req *CalendarCompRequest) (*CalendarObject, error)
 	ListCalendarObjects(ctx context.Context, path string, req *CalendarCompRequest) ([]CalendarObject, error)
-	QueryCalendarObjects(ctx context.Context, query *CalendarQuery) ([]CalendarObject, error)
+	QueryCalendarObjects(ctx context.Context, path string, query *CalendarQuery) ([]CalendarObject, error)
 	PutCalendarObject(ctx context.Context, path string, calendar *ical.Calendar, opts *PutCalendarObjectOptions) (loc string, err error)
 	DeleteCalendarObject(ctx context.Context, path string) error
 
@@ -213,7 +213,7 @@ func (h *Handler) handleQuery(r *http.Request, w http.ResponseWriter, query *cal
 	}
 	q.CompFilter = *cf
 
-	cos, err := h.Backend.QueryCalendarObjects(r.Context(), &q)
+	cos, err := h.Backend.QueryCalendarObjects(r.Context(), r.URL.Path, &q)
 	if err != nil {
 		return err
 	}

--- a/caldav/server_test.go
+++ b/caldav/server_test.go
@@ -226,6 +226,6 @@ func (t testBackend) ListCalendarObjects(ctx context.Context, path string, req *
 	return t.objectMap[path], nil
 }
 
-func (t testBackend) QueryCalendarObjects(ctx context.Context, query *CalendarQuery) ([]CalendarObject, error) {
+func (t testBackend) QueryCalendarObjects(ctx context.Context, path string, query *CalendarQuery) ([]CalendarObject, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This was missing for proper multi-calendar support.

--

Not sure why this wasn't added in #127, but it looks like just oversight to me? A query (a.k.a. a REPORT request) has to be made against a specific calendar (or a calendar object resource), so the backend has to know which one.