### PR TITLE
carddav: support multiple address books

### DIFF
--- a/server.go
+++ b/server.go
@@ -255,7 +255,7 @@ func (b *backend) Move(r *http.Request, dest *internal.Href, overwrite bool) (cr
 
 // BackendSuppliedHomeSet represents either a CalDAV calendar-home-set or a
 // CardDAV addressbook-home-set. It should only be created via
-// caldav.NewCalendarHomeSet or carddav.NewAddressbookHomeSet. Only to
+// caldav.NewCalendarHomeSet or carddav.NewAddressBookHomeSet. Only to
 // be used server-side, for listing a user's home sets as determined by the
 // (external) backend.
 type BackendSuppliedHomeSet interface {


### PR DESCRIPTION
This is the equivalent of #127 (and #140) for CardDAV and finally allows backends to serve different address books to different users.

While I'm breaking the interface, correct one last instance of "Addressbook" to "AddressBook" (in `AddressBookHomeSetPath`).