### PR TITLE
carddav: support address book creation/deletion

### DIFF
--- a/carddav/carddav_test.go
+++ b/carddav/carddav_test.go
@@ -68,6 +68,14 @@ func (b *testBackend) GetAddressBook(ctx context.Context, path string) (*Address
 	return nil, webdav.NewHTTPError(404, fmt.Errorf("Not found"))
 }
 
+func (*testBackend) CreateAddressBook(ctx context.Context, ab AddressBook) error {
+	panic("TODO: implement")
+}
+
+func (*testBackend) DeleteAddressBook(ctx context.Context, path string) error {
+	panic("TODO: implement")
+}
+
 func (*testBackend) GetAddressObject(ctx context.Context, path string, req *AddressDataRequest) (*AddressObject, error) {
 	if path == alicePath {
 		card, err := vcard.NewDecoder(strings.NewReader(aliceData)).Decode()

--- a/carddav/elements.go
+++ b/carddav/elements.go
@@ -211,3 +211,11 @@ func (r *reportReq) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 	return d.DecodeElement(v, &start)
 }
+
+type mkcolReq struct {
+	XMLName      xml.Name               `xml:"DAV: mkcol"`
+	ResourceType internal.ResourceType  `xml:"set>prop>resourcetype"`
+	DisplayName  string                 `xml:"set>prop>displayname"`
+	Description  addressbookDescription `xml:"set>prop>addressbook-description"`
+	// TODO this could theoretically contain all addressbook properties?
+}


### PR DESCRIPTION
Now that the handling for multiple address books is in place, this commit adds initial support for creation and deletion of address books.

These operations obviously require support from the backend, so the interface gains two new methods. All properties of the address book passed to `CreateAddressBook()` may be unset, except for the path (e.g. when a client sends a MKCOL request without a body. It is up to the backend to put any desired default values in place. As is, the parsing of the request body still needs some improvements, but correctly handles the most common properties.

Using this as is (in tokidoki), I can successfully create and delete address books using DavX5. The validation is not great yet, but since this touches the interface again, I wanted to make sure early on that this looks like the right approach to you.