### PR TITLE
*: displayname, desription are optional

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -530,9 +530,6 @@ func (b *backend) propFindCalendar(ctx context.Context, propfind *internal.PropF
 		internal.ResourceTypeName: func(*internal.RawXMLValue) (interface{}, error) {
 			return internal.NewResourceType(internal.CollectionName, calendarName), nil
 		},
-		internal.DisplayNameName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &internal.DisplayName{Name: cal.Name}, nil
-		},
 		calendarDescriptionName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &calendarDescription{Description: cal.Description}, nil
 		},
@@ -558,12 +555,16 @@ func (b *backend) propFindCalendar(ctx context.Context, propfind *internal.PropF
 		},
 	}
 
+	if cal.Name != "" {
+		props[internal.DisplayNameName] = func(*internal.RawXMLValue) (interface{}, error) {
+			return &internal.DisplayName{Name: cal.Name}, nil
+		}
+	}
 	if cal.Description != "" {
 		props[calendarDescriptionName] = func(*internal.RawXMLValue) (interface{}, error) {
 			return &calendarDescription{Description: cal.Description}, nil
 		}
 	}
-
 	if cal.MaxResourceSize > 0 {
 		props[maxResourceSizeName] = func(*internal.RawXMLValue) (interface{}, error) {
 			return &maxResourceSize{Size: cal.MaxResourceSize}, nil

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -499,12 +499,6 @@ func (b *backend) propFindAddressBook(ctx context.Context, propfind *internal.Pr
 		internal.ResourceTypeName: func(*internal.RawXMLValue) (interface{}, error) {
 			return internal.NewResourceType(internal.CollectionName, addressBookName), nil
 		},
-		internal.DisplayNameName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &internal.DisplayName{Name: ab.Name}, nil
-		},
-		addressBookDescriptionName: func(*internal.RawXMLValue) (interface{}, error) {
-			return &addressbookDescription{Description: ab.Description}, nil
-		},
 		supportedAddressDataName: func(*internal.RawXMLValue) (interface{}, error) {
 			return &supportedAddressData{
 				Types: []addressDataType{
@@ -515,6 +509,16 @@ func (b *backend) propFindAddressBook(ctx context.Context, propfind *internal.Pr
 		},
 	}
 
+	if ab.Name != "" {
+		props[internal.DisplayNameName] = func(*internal.RawXMLValue) (interface{}, error) {
+			return &internal.DisplayName{Name: ab.Name}, nil
+		}
+	}
+	if ab.Description != "" {
+		props[addressBookDescriptionName] = func(*internal.RawXMLValue) (interface{}, error) {
+			return &addressbookDescription{Description: ab.Description}, nil
+		}
+	}
 	if ab.MaxResourceSize > 0 {
 		props[maxResourceSizeName] = func(*internal.RawXMLValue) (interface{}, error) {
 			return &maxResourceSize{Size: ab.MaxResourceSize}, nil


### PR DESCRIPTION
Both the displayname and the description can be absent for both calendars and address books. If this is the case they should not show up in PROPFIND responses as empty string.