### PR TITLE
internal: no status element in propstat responses

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -173,7 +173,7 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) error {
 type PropFindFunc func(raw *RawXMLValue) (interface{}, error)
 
 func NewPropFindResponse(path string, propfind *PropFind, props map[xml.Name]PropFindFunc) (*Response, error) {
-	resp := NewOKResponse(path)
+	resp := &Response{Hrefs: []Href{Href{Path: path}}}
 
 	if _, ok := props[ResourceTypeName]; !ok {
 		props[ResourceTypeName] = func(*RawXMLValue) (interface{}, error) {


### PR DESCRIPTION
Responses that contain propstat elements do not contain their own top-level status element, only the status elements inside the propstat element.

See https://datatracker.ietf.org/doc/html/rfc4918#section-14.24 or any of the examples for PROPFIND/PROPPATCH, starting e.g. here: https://datatracker.ietf.org/doc/html/rfc4918#section-9.1.3