### PR TITLE
webdav: add size to FileSystem.Create()

### DIFF
--- a/fs_local.go
+++ b/fs_local.go
@@ -114,7 +114,7 @@ func (fs LocalFileSystem) ReadDir(ctx context.Context, name string, recursive bo
 	return l, errFromOS(err)
 }
 
-func (fs LocalFileSystem) Create(ctx context.Context, name string, body io.ReadCloser) error {
+func (fs LocalFileSystem) Create(ctx context.Context, name string, body io.ReadCloser, size int64) error {
 	p, err := fs.localPath(name)
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -17,7 +17,7 @@ type FileSystem interface {
 	Open(ctx context.Context, name string) (io.ReadCloser, error)
 	Stat(ctx context.Context, name string) (*FileInfo, error)
 	ReadDir(ctx context.Context, name string, recursive bool) ([]FileInfo, error)
-	Create(ctx context.Context, name string, body io.ReadCloser) error
+	Create(ctx context.Context, name string, body io.ReadCloser, size int64) error
 	RemoveAll(ctx context.Context, name string) error
 	Mkdir(ctx context.Context, name string) error
 	Copy(ctx context.Context, name, dest string, options *CopyOptions) (created bool, err error)
@@ -45,7 +45,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // NewHTTPError creates a new error that is associated with an HTTP status code
 // and optionally an error that lead to it. Backends can use this functions to
 // return errors that convey some semantics (e.g. 404 not found, 403 access
-// denied, etc) while also providing an (optional) arbitrary error context
+// denied, etc.) while also providing an (optional) arbitrary error context
 // (intended for humans).
 func NewHTTPError(statusCode int, cause error) error {
 	return &internal.HTTPError{Code: statusCode, Err: cause}
@@ -194,7 +194,7 @@ func (b *backend) PropPatch(r *http.Request, update *internal.PropertyUpdate) (*
 }
 
 func (b *backend) Put(w http.ResponseWriter, r *http.Request) error {
-	err := b.FileSystem.Create(r.Context(), r.URL.Path, r.Body)
+	err := b.FileSystem.Create(r.Context(), r.URL.Path, r.Body, r.ContentLength)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In some cases the total size is necessary upfront to perform the upload to an external system.

And even if not it is good to have it as a minimal test to see if data was transmitted completely ....

Open question:
how to address other valuable headers like checksums or what ever ....

maybe we pass the full request object to Create()?
Or body + headers?

@emersion any objections/idea?