### PR TITLE
caldav: add expand request to client

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -79,6 +79,12 @@ type CalendarCompRequest struct {
 
 	AllComps bool
 	Comps    []CalendarCompRequest
+
+	Expand *CalendarExpandRequest
+}
+
+type CalendarExpandRequest struct {
+	Start, End time.Time
 }
 
 type CompFilter struct {

--- a/caldav/client.go
+++ b/caldav/client.go
@@ -154,7 +154,9 @@ func encodeCalendarReq(c *CalendarCompRequest) (*internal.Prop, error) {
 		return nil, err
 	}
 
-	calDataReq := calendarDataReq{Comp: compReq}
+	expandReq := encodeExpandRequest(c.Expand)
+
+	calDataReq := calendarDataReq{Comp: compReq, Expand: expandReq}
 
 	getLastModReq := internal.NewRawXMLElement(internal.GetLastModifiedName, nil, nil)
 	getETagReq := internal.NewRawXMLElement(internal.GetETagName, nil, nil)
@@ -211,6 +213,17 @@ func encodeTextMatch(tm *TextMatch) *textMatch {
 		NegateCondition: negateCondition(tm.NegateCondition),
 	}
 	return encoded
+}
+
+func encodeExpandRequest(e *CalendarExpandRequest) *expand {
+	if e == nil {
+		return nil
+	}
+	encoded := expand{
+		Start: dateWithUTCTime(e.Start),
+		End:   dateWithUTCTime(e.End),
+	}
+	return &encoded
 }
 
 func decodeCalendarObjectList(ms *internal.MultiStatus) ([]CalendarObject, error) {

--- a/caldav/elements.go
+++ b/caldav/elements.go
@@ -179,7 +179,8 @@ func (t *dateWithUTCTime) MarshalText() ([]byte, error) {
 type calendarDataReq struct {
 	XMLName xml.Name `xml:"urn:ietf:params:xml:ns:caldav calendar-data"`
 	Comp    *comp    `xml:"comp,omitempty"`
-	// TODO: expand, limit-recurrence-set, limit-freebusy-set
+	Expand  *expand  `xml:"expand,omitempty"`
+	// TODO: limit-recurrence-set, limit-freebusy-set
 }
 
 // https://tools.ietf.org/html/rfc4791#section-9.6.1
@@ -192,6 +193,12 @@ type comp struct {
 
 	Allcomp *struct{} `xml:"allcomp,omitempty"`
 	Comp    []comp    `xml:"comp,omitempty"`
+}
+
+type expand struct {
+	XMLName xml.Name        `xml:"urn:ietf:params:xml:ns:caldav expand"`
+	Start   dateWithUTCTime `xml:"start,attr"`
+	End     dateWithUTCTime `xml:"end,attr"`
 }
 
 // https://tools.ietf.org/html/rfc4791#section-9.6.4


### PR DESCRIPTION
I needed the expand request for a project I'm working on (wanted recurring events to show at the correct date), so I went ahead and added it!

This is a pull request fixing my previous pull request that had import renames polluting the commit history