### PR TITLE
caldav, carddav: redirect on wrong `principalPath` or `homeSetPath` instead of empty MultiStatus response

### DIFF
--- a/caldav/server.go
+++ b/caldav/server.go
@@ -366,7 +366,7 @@ func (b *backend) HeadGet(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (b *backend) PropFind(r *http.Request, propfind *internal.PropFind, depth internal.Depth) (*internal.MultiStatus, error) {
+func (b *backend) PropFind(w http.ResponseWriter, r *http.Request, propfind *internal.PropFind, depth internal.Depth) error {
 	resType := b.resourceTypeAtPath(r.URL.Path)
 
 	var dataReq CalendarCompRequest
@@ -376,86 +376,92 @@ func (b *backend) PropFind(r *http.Request, propfind *internal.PropFind, depth i
 	case resourceTypeRoot:
 		resp, err := b.propFindRoot(r.Context(), propfind)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		resps = append(resps, *resp)
 	case resourceTypeUserPrincipal:
 		principalPath, err := b.Backend.CurrentUserPrincipal(r.Context())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if r.URL.Path == principalPath {
 			resp, err := b.propFindUserPrincipal(r.Context(), propfind)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			resps = append(resps, *resp)
 			if depth != internal.DepthZero {
 				resp, err := b.propFindHomeSet(r.Context(), propfind)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				resps = append(resps, *resp)
 				if depth == internal.DepthInfinity {
 					resps_, err := b.propFindAllCalendars(r.Context(), propfind, true)
 					if err != nil {
-						return nil, err
+						return err
 					}
 					resps = append(resps, resps_...)
 				}
 			}
+		} else {
+			http.Redirect(w, r, principalPath, http.StatusPermanentRedirect) // keep http method
+			return nil
 		}
 	case resourceTypeCalendarHomeSet:
 		homeSetPath, err := b.Backend.CalendarHomeSetPath(r.Context())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if r.URL.Path == homeSetPath {
 			resp, err := b.propFindHomeSet(r.Context(), propfind)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			resps = append(resps, *resp)
 			if depth != internal.DepthZero {
 				recurse := depth == internal.DepthInfinity
 				resps_, err := b.propFindAllCalendars(r.Context(), propfind, recurse)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				resps = append(resps, resps_...)
 			}
+		} else {
+			http.Redirect(w, r, homeSetPath, http.StatusPermanentRedirect) // keep http method
+			return nil
 		}
 	case resourceTypeCalendar:
 		ab, err := b.Backend.GetCalendar(r.Context(), r.URL.Path)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		resp, err := b.propFindCalendar(r.Context(), propfind, ab)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		resps = append(resps, *resp)
 		if depth != internal.DepthZero {
 			resps_, err := b.propFindAllCalendarObjects(r.Context(), propfind, ab)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			resps = append(resps, resps_...)
 		}
 	case resourceTypeCalendarObject:
 		ao, err := b.Backend.GetCalendarObject(r.Context(), r.URL.Path, &dataReq)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		resp, err := b.propFindCalendarObject(r.Context(), propfind, ao)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		resps = append(resps, *resp)
 	}
 
-	return internal.NewMultiStatus(resps...), nil
+	return internal.ServeMultiStatus(w, internal.NewMultiStatus(resps...))
 }
 
 func (b *backend) propFindRoot(ctx context.Context, propfind *internal.PropFind) (*internal.Response, error) {

--- a/internal/server.go
+++ b/internal/server.go
@@ -64,7 +64,7 @@ func ServeMultiStatus(w http.ResponseWriter, ms *MultiStatus) error {
 type Backend interface {
 	Options(r *http.Request) (caps []string, allow []string, err error)
 	HeadGet(w http.ResponseWriter, r *http.Request) error
-	PropFind(r *http.Request, pf *PropFind, depth Depth) (*MultiStatus, error)
+	PropFind(w http.ResponseWriter, r *http.Request, pf *PropFind, depth Depth) error
 	PropPatch(r *http.Request, pu *PropertyUpdate) (*Response, error)
 	Put(w http.ResponseWriter, r *http.Request) error
 	Delete(r *http.Request) error
@@ -152,12 +152,7 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	ms, err := h.Backend.PropFind(r, &propfind, depth)
-	if err != nil {
-		return err
-	}
-
-	return ServeMultiStatus(w, ms)
+	return h.Backend.PropFind(w, r, &propfind, depth)
 }
 
 type PropFindFunc func(raw *RawXMLValue) (interface{}, error)


### PR DESCRIPTION
Before this PR if the client was requesting a wrong `principalPath` or `homeSetPath` it would get an empty `207 Multistatus` response.

With this PR, the client would get a 308 redirect response instead.

Concrete usecase: when an iOS user makes a change to its username, iOS will automatically update the principal URL if it receives a redirect response.

I tried to send the redirection inside the 207 (using `location`), but couldn't get it to work (don't know if I did something wrong, or if iOS does not support it).

_PS: this change is available in the `main` branch of my fork: https://github.com/oliverpool/go-webdav/_