### PR TITLE
Support prop-filter in client requests

### DIFF
--- a/caldav/client.go
+++ b/caldav/client.go
@@ -172,7 +172,45 @@ func encodeCompFilter(filter *CompFilter) *compFilter {
 	for _, child := range filter.Comps {
 		encoded.CompFilters = append(encoded.CompFilters, *encodeCompFilter(&child))
 	}
+	for _, pf := range filter.Props {
+		encoded.PropFilters = append(encoded.PropFilters, *encodePropFilter(&pf))
+	}
 	return &encoded
+}
+
+func encodePropFilter(filter *PropFilter) *propFilter {
+	encoded := propFilter{Name: filter.Name}
+	if !filter.Start.IsZero() || !filter.End.IsZero() {
+		encoded.TimeRange = &timeRange{
+			Start: dateWithUTCTime(filter.Start),
+			End:   dateWithUTCTime(filter.End),
+		}
+	}
+	encoded.TextMatch = encodeTextMatch(filter.TextMatch)
+	for _, pf := range filter.ParamFilter {
+		encoded.ParamFilter = append(encoded.ParamFilter, encodeParamFilter(pf))
+	}
+	return &encoded
+}
+
+func encodeParamFilter(pf ParamFilter) paramFilter {
+	encoded := paramFilter{
+		Name:      pf.Name,
+		TextMatch: encodeTextMatch(pf.TextMatch),
+	}
+	return encoded
+}
+
+func encodeTextMatch(tm *TextMatch) *textMatch {
+	if tm == nil {
+		return nil
+	}
+
+	encoded := &textMatch{
+		Text:            tm.Text,
+		NegateCondition: negateCondition(tm.NegateCondition),
+	}
+	return encoded
 }
 
 func decodeCalendarObjectList(ms *internal.MultiStatus) ([]CalendarObject, error) {


### PR DESCRIPTION
This change set adds support for correctly encoding the prop filters into calendar requests.

Example Request with this change set:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<calendar-query
	xmlns="urn:ietf:params:xml:ns:caldav">
	<prop
		xmlns="DAV:">
		<calendar-data
			xmlns="urn:ietf:params:xml:ns:caldav">
			<comp
				xmlns="urn:ietf:params:xml:ns:caldav" name="VCALENDAR">
				<comp
					xmlns="urn:ietf:params:xml:ns:caldav" name="VEVENT">
					<prop
						xmlns="urn:ietf:params:xml:ns:caldav" name="UID">
					</prop>
					<prop
						xmlns="urn:ietf:params:xml:ns:caldav" name="ATTENDEE">
					</prop>
				</comp>
			</comp>
		</calendar-data>
		<getlastmodified
			xmlns="DAV:">
		</getlastmodified>
		<getetag
			xmlns="DAV:">
		</getetag>
	</prop>
	<filter
		xmlns="urn:ietf:params:xml:ns:caldav">
		<comp-filter
			xmlns="urn:ietf:params:xml:ns:caldav" name="VCALENDAR">
			<comp-filter
				xmlns="urn:ietf:params:xml:ns:caldav" name="VEVENT">
				<prop-filter
					xmlns="urn:ietf:params:xml:ns:caldav" name="UID">
					<text-match
						xmlns="urn:ietf:params:xml:ns:caldav">5bf5ee84-a9cf-4319-9def-437b00e2be8d
					</text-match>
				</prop-filter>
			</comp-filter>
		</comp-filter>
	</filter>
</calendar-query
```