### PR TITLE
webdav: handle permission errors in ReadDir

### DIFF
--- a/fs_local.go
+++ b/fs_local.go
@@ -103,8 +103,11 @@ func (fs LocalFileSystem) ReadDir(ctx context.Context, name string, recursive bo
 
 	var l []FileInfo
 	err = filepath.Walk(path, func(p string, fi os.FileInfo, err error) error {
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrPermission) {
 			return err
+		}
+		if fi == nil {
+			return nil
 		}
 
 		href, err := fs.externalPath(p)


### PR DESCRIPTION
We shouldn't stop the walk on first error, but continue and return all
the children we can. If stat fails we should just skip current entry and
move on.