### PR TITLE
internal/server: handle "allprop" with empty request and XML content type

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -139,6 +139,8 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) error {
 		if err := DecodeXMLRequest(r, &propfind); err != nil {
 			return err
 		}
+	} else {
+		return HTTPErrorf(http.StatusBadRequest, "webdav: unsupported request body")
 	}
 
 	depth := DepthInfinity

--- a/internal/server.go
+++ b/internal/server.go
@@ -131,16 +131,14 @@ func (h *Handler) handleOptions(w http.ResponseWriter, r *http.Request) error {
 
 func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) error {
 	var propfind PropFind
-	if isContentXML(r.Header) {
+	if IsRequestBodyEmpty(r) {
+		// NOTE: properly handle PROPFIND requests without a body,
+		// regardless of the "Content-Type" header of the request.
+		propfind.AllProp = &struct{}{}
+	} else if isContentXML(r.Header) {
 		if err := DecodeXMLRequest(r, &propfind); err != nil {
 			return err
 		}
-	} else {
-		var b [1]byte
-		if _, err := r.Body.Read(b[:]); err != io.EOF {
-			return HTTPErrorf(http.StatusBadRequest, "webdav: unsupported request body")
-		}
-		propfind.AllProp = &struct{}{}
 	}
 
 	depth := DepthInfinity


### PR DESCRIPTION
The previous code failed to properly handle PROPFIND with an empty request body (RFC 4918 section 9.1) for XML content type requests.

Refactor the logic to always consider PROPFIND requests with empty request bodies as "allprop" requests, regardless of content type.

There is no need to worry about the request's content type if the request body is empty anyway, so only parse if we know it is not.