### PR TITLE
internal: tolerate unquoted ETags from non-compliant servers

### DIFF
--- a/internal/elements.go
+++ b/internal/elements.go
@@ -385,8 +385,16 @@ type GetETag struct {
 type ETag string
 
 func (etag *ETag) UnmarshalText(b []byte) error {
-	s, err := strconv.Unquote(string(b))
+	raw := string(b)
+	s, err := strconv.Unquote(raw)
 	if err != nil {
+		// Some servers (e.g. mailbox.org) return ETags without the required
+		// surrounding double-quotes (RFC 4918 §15.6). Accept the raw value
+		// rather than failing hard, so callers can still sync.
+		if len(raw) > 0 {
+			*etag = ETag(raw)
+			return nil
+		}
 		return fmt.Errorf("webdav: failed to unquote ETag: %v", err)
 	}
 	*etag = ETag(s)

--- a/internal/elements_test.go
+++ b/internal/elements_test.go
@@ -43,6 +43,55 @@ func TestResponse_Err_error(t *testing.T) {
 	}
 }
 
+func TestETagUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ETag
+	}{
+		{
+			name:  "quoted (RFC-compliant)",
+			input: `"abc123"`,
+			want:  "abc123",
+		},
+		{
+			name:  "unquoted (non-compliant server, e.g. mailbox.org)",
+			input: `abc123`,
+			want:  "abc123",
+		},
+		{
+			name:  "quoted with special characters",
+			input: `"etag/with-dashes_and.dots"`,
+			want:  "etag/with-dashes_and.dots",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ETag
+			if err := got.UnmarshalText([]byte(tc.input)); err != nil {
+				t.Fatalf("UnmarshalText(%q) error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("UnmarshalText(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestETagRoundTrip(t *testing.T) {
+	var etag ETag
+	if err := etag.UnmarshalText([]byte(`"abc123"`)); err != nil {
+		t.Fatalf("UnmarshalText error: %v", err)
+	}
+	b, err := etag.MarshalText()
+	if err != nil {
+		t.Fatalf("MarshalText error: %v", err)
+	}
+	if string(b) != `"abc123"` {
+		t.Errorf("MarshalText = %q, want %q", b, `"abc123"`)
+	}
+}
+
 func TestTimeRoundTrip(t *testing.T) {
 	now := Time(time.Now().UTC())
 	want, err := now.MarshalText()


### PR DESCRIPTION
## Problem

RFC 4918 §15.6 requires ETags to be quoted strings, but some servers return them without surrounding double-quotes. mailbox.org CalDAV is one example:

```
<DAV: getetag>Y2FsOi8vMC8zMg</DAV: getetag>
```

`strconv.Unquote` fails with `invalid syntax` on such values, causing the whole calendar sync to abort with:

```
property <DAV: getetag>: webdav: failed to unquote ETag: invalid syntax
```

## Fix

When `strconv.Unquote` fails and the raw value is non-empty, fall back to accepting the raw value as-is. Empty strings still return an error.

## Tests

Added `TestETagUnmarshal` covering:
- Quoted ETags (RFC-compliant)
- Unquoted ETags (non-compliant server, e.g. mailbox.org)
- Quoted ETags with special characters

Added `TestETagRoundTrip` verifying that marshal→unmarshal produces the correct quoted form.