### PR TITLE
caldav: decode inline calendar-data in SyncCollection responses

### DIFF
--- a/caldav/client.go
+++ b/caldav/client.go
@@ -515,6 +515,22 @@ func (c *Client) SyncCollection(ctx context.Context, path string, query *SyncQue
 			ModTime: time.Time(getLastMod.LastModified),
 			ETag:    string(getETag.ETag),
 		}
+
+		// Many servers return the calendar-data inline in the sync-collection
+		// response (the query already requests it via CompRequest); decode it so
+		// the caller need not follow up with a multiget. When the server omits the
+		// data, Data is left nil and the caller fetches it as before.
+		var calData calendarDataResp
+		if err := resp.DecodeProp(&calData); err == nil {
+			cal, err := ical.NewDecoder(bytes.NewReader(calData.Data)).Decode()
+			if err != nil {
+				return nil, err
+			}
+			o.Data = cal
+		} else if !internal.IsNotFound(err) {
+			return nil, err
+		}
+
 		ret.Updated = append(ret.Updated, o)
 	}
 


### PR DESCRIPTION
`SyncCollection` already requests `calendar-data` via the query's `CompRequest`, but only the `getetag`/`getlastmodified` props are decoded from each response. So a caller must follow every sync with a `MultiGetCalendar` to fetch bodies — even when the server already returned the calendar object **inline** in the sync-collection response, which Radicale, SOGo and others do when the prop is requested.

This decodes the `calendar-data` prop into `CalendarObject.Data` when present, saving the extra round-trip. When the server omits it (returns hrefs/ETags only), `Data` stays `nil` and the caller fetches it with a multiget exactly as before — so the change is backward compatible.

The decode mirrors `decodeCalendarObjectList` (same `calendarDataResp` + `ical` decode) and treats a missing `calendar-data` prop as "no inline data" via `internal.IsNotFound`.

I held off on a test because the existing `caldav` client tests exercise the `Handler` (server side) via `httptest.NewRecorder` rather than the client against canned responses — happy to add one in whatever form you prefer (a stub server returning an inline sync-collection multistatus, or server-side sync-collection support so a round-trip test works).

Context: hit this building a Microsoft Graph mailbox server that maps `/me/events/delta` onto CalDAV sync-collection; Radicale inlines the data, so the follow-up multiget is pure overhead.

Developed with [Claude Code](https://claude.com/claude-code).