### PR TITLE
caldav, carddav: derive current-user-privilege-set from a read-only flag

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -69,6 +69,9 @@ type Calendar struct {
 	Description           string
 	MaxResourceSize       int64
 	SupportedComponentSet []string
+	// ReadOnly reports that the current user may only read this calendar. It
+	// controls the DAV:current-user-privilege-set reported by the server.
+	ReadOnly bool
 }
 
 type CalendarCompRequest struct {

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -546,13 +546,7 @@ func (b *backend) propFindCalendar(ctx context.Context, propfind *internal.PropF
 				Comp: components,
 			}, nil
 		},
-		// TODO: Gather UserPrivilege from backend to control read-and-write
-		internal.CurrentUserPrivilegeSetName: internal.PropFindValue(&internal.CurrentUserPrivilegeSet{
-			Privilege: []internal.Privilege{{
-				Read:  &struct{}{},
-				Write: &struct{}{},
-			}},
-		}),
+		internal.CurrentUserPrivilegeSetName: internal.PropFindValue(internal.NewCurrentUserPrivilegeSet(cal.ReadOnly)),
 	}
 
 	if cal.Name != "" {

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -28,6 +28,9 @@ type AddressBook struct {
 	Description          string
 	MaxResourceSize      int64
 	SupportedAddressData []AddressDataType
+	// ReadOnly reports that the current user may only read this address book.
+	// It controls the DAV:current-user-privilege-set reported by the server.
+	ReadOnly bool
 }
 
 func (ab *AddressBook) SupportsAddressData(contentType, version string) bool {

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -497,13 +497,7 @@ func (b *backend) propFindAddressBook(ctx context.Context, propfind *internal.Pr
 				{ContentType: vcard.MIMEType, Version: "4.0"},
 			},
 		}),
-		// TODO: Gather UserPrivilege from backend to control read-and-write
-		internal.CurrentUserPrivilegeSetName: internal.PropFindValue(&internal.CurrentUserPrivilegeSet{
-			Privilege: []internal.Privilege{{
-				Read:  &struct{}{},
-				Write: &struct{}{},
-			}},
-		}),
+		internal.CurrentUserPrivilegeSetName: internal.PropFindValue(internal.NewCurrentUserPrivilegeSet(ab.ReadOnly)),
 	}
 
 	if ab.Name != "" {

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -471,3 +471,13 @@ type Privilege struct {
 	Read    *struct{} `xml:"DAV: read,omitempty"`
 	Write   *struct{} `xml:"DAV: write,omitempty"`
 }
+
+// NewCurrentUserPrivilegeSet returns a privilege set granting DAV:read, plus
+// DAV:write unless readOnly is set.
+func NewCurrentUserPrivilegeSet(readOnly bool) *CurrentUserPrivilegeSet {
+	priv := Privilege{Read: &struct{}{}}
+	if !readOnly {
+		priv.Write = &struct{}{}
+	}
+	return &CurrentUserPrivilegeSet{Privilege: []Privilege{priv}}
+}


### PR DESCRIPTION
## Summary

Both servers hard-code `DAV:read` + `DAV:write` in `DAV:current-user-privilege-set`
for every collection, with a `// TODO: Gather UserPrivilege from backend` left in
`propFindCalendar` and `propFindAddressBook`.

As a result, a client (DAVx5, Apple Calendar/Contacts, Thunderbird) is always told
it may write — even for collections the backend serves read-only. The client only
finds out otherwise when a `PUT`/`DELETE` is rejected, by which point it may have
already accepted a local edit it then has to roll back. That's poor UX and, with
some clients, a data-loss risk.

## Change

- Add a `ReadOnly bool` field to `caldav.Calendar` and `carddav.AddressBook`; the
  backend sets it per request.
- Add `internal.NewCurrentUserPrivilegeSet(readOnly bool)`, which always grants
  `DAV:read` and grants `DAV:write` only when `readOnly` is false.
- Wire both servers to build the privilege set from the flag, removing the two TODOs.

`ReadOnly` defaults to `false`, so existing backends keep the current read-write
behavior with no code changes.
