### PR TITLE
caldav, carddav: support the CalendarServer getctag property

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -69,6 +69,9 @@ type Calendar struct {
 	Description           string
 	MaxResourceSize       int64
 	SupportedComponentSet []string
+	// CTag, when set, is reported as the CalendarServer getctag property: an
+	// opaque token that must change whenever the calendar's contents change.
+	CTag string
 }
 
 type CalendarCompRequest struct {

--- a/caldav/server.go
+++ b/caldav/server.go
@@ -570,6 +570,9 @@ func (b *backend) propFindCalendar(ctx context.Context, propfind *internal.PropF
 			Size: cal.MaxResourceSize,
 		})
 	}
+	if cal.CTag != "" {
+		props[internal.GetCTagName] = internal.PropFindValue(&internal.GetCTag{CTag: cal.CTag})
+	}
 
 	// TODO: CALDAV:calendar-timezone, CALDAV:supported-calendar-component-set, CALDAV:min-date-time, CALDAV:max-date-time, CALDAV:max-instances, CALDAV:max-attendees-per-instance
 

--- a/carddav/carddav.go
+++ b/carddav/carddav.go
@@ -28,6 +28,9 @@ type AddressBook struct {
 	Description          string
 	MaxResourceSize      int64
 	SupportedAddressData []AddressDataType
+	// CTag, when set, is reported as the CalendarServer getctag property: an
+	// opaque token that must change whenever the address book's contents change.
+	CTag string
 }
 
 func (ab *AddressBook) SupportsAddressData(contentType, version string) bool {

--- a/carddav/server.go
+++ b/carddav/server.go
@@ -521,6 +521,9 @@ func (b *backend) propFindAddressBook(ctx context.Context, propfind *internal.Pr
 			Size: ab.MaxResourceSize,
 		})
 	}
+	if ab.CTag != "" {
+		props[internal.GetCTagName] = internal.PropFindValue(&internal.GetCTag{CTag: ab.CTag})
+	}
 
 	return internal.NewPropFindResponse(ab.Path, propfind, props)
 }

--- a/internal/elements.go
+++ b/internal/elements.go
@@ -471,3 +471,18 @@ type Privilege struct {
 	Read    *struct{} `xml:"DAV: read,omitempty"`
 	Write   *struct{} `xml:"DAV: write,omitempty"`
 }
+
+// CalendarServerNamespace is the namespace of the CalendarServer extensions.
+const CalendarServerNamespace = "http://calendarserver.org/ns/"
+
+var GetCTagName = xml.Name{CalendarServerNamespace, "getctag"}
+
+// GetCTag is the CalendarServer getctag property: an opaque token that changes
+// whenever the collection's contents change, letting clients detect changes
+// without enumerating every member's ETag. Despite the "calendarserver"
+// namespace, the same property and namespace are used for CardDAV address
+// books, not only CalDAV calendars.
+type GetCTag struct {
+	XMLName xml.Name `xml:"http://calendarserver.org/ns/ getctag"`
+	CTag    string   `xml:",chardata"`
+}


### PR DESCRIPTION
## Summary

Add optional support for the `getctag` property from the CalendarServer extension
namespace (`http://calendarserver.org/ns/`). `getctag` is an opaque collection-level
token that changes whenever the collection's contents change, letting clients
(DAVx5, Apple, etc.) detect "did anything change?" with a single `PROPFIND` on the
collection instead of enumerating every member's `ETag`. It's widely supported and
is the change-detection fallback for clients that don't use `sync-collection`.

## Change

- Add a `CTag string` field to `caldav.Calendar` and `carddav.AddressBook`.
- Add the `internal.GetCTag` element, `internal.GetCTagName`, and a
  `CalendarServerNamespace` constant.
- In `propFindCalendar` / `propFindAddressBook`, report `getctag` when `CTag` is
  non-empty.

When `CTag` is empty (the default), the property is omitted entirely, so existing
backends are unaffected.

## Notes

- Although the property lives in the "calendarserver" namespace, the same
  property/namespace is also used for CardDAV address books (per the CalendarServer
  convention and as implemented by SabreDAV / dav4jvm / Apple). The shared
  `internal.GetCTag` reflects that; a clarifying comment is included in the code.
