### PR TITLE
caldav, carddav: support If-Match/If-None-Match on client PUT

### DIFF
--- a/caldav/client.go
+++ b/caldav/client.go
@@ -432,9 +432,13 @@ func (c *Client) GetCalendarObject(ctx context.Context, path string) (*CalendarO
 	return co, nil
 }
 
-func (c *Client) PutCalendarObject(ctx context.Context, path string, cal *ical.Calendar) (*CalendarObject, error) {
-	// TODO: add support for If-None-Match and If-Match
-
+// PutCalendarObject stores cal as the calendar object resource at path. A nil
+// opts performs an unconditional PUT; a non-nil opts may carry an If-Match
+// (overwrite only if the resource still has this ETag) or If-None-Match
+// (create only if absent) precondition. A failed precondition surfaces as an
+// error whose status code is 412 Precondition Failed, readable via
+// webdav.HTTPErrorCode.
+func (c *Client) PutCalendarObject(ctx context.Context, path string, cal *ical.Calendar, opts *PutCalendarObjectOptions) (*CalendarObject, error) {
 	// TODO: some servers want a Content-Length header, so we can't stream the
 	// request body here. See the Radicale issue:
 	// https://github.com/Kozea/Radicale/issues/1016
@@ -449,6 +453,14 @@ func (c *Client) PutCalendarObject(ctx context.Context, path string, cal *ical.C
 		return nil, err
 	}
 	req.Header.Set("Content-Type", ical.MIMEType)
+	if opts != nil {
+		if opts.IfMatch.IsSet() {
+			req.Header.Set("If-Match", string(opts.IfMatch))
+		}
+		if opts.IfNoneMatch.IsSet() {
+			req.Header.Set("If-None-Match", string(opts.IfNoneMatch))
+		}
+	}
 
 	resp, err := c.ic.Do(req.WithContext(ctx))
 	if err != nil {

--- a/caldav/client_ifmatch_test.go
+++ b/caldav/client_ifmatch_test.go
@@ -1,0 +1,108 @@
+package caldav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav"
+)
+
+// minimalCalendar builds a single-VEVENT VCALENDAR valid enough to encode.
+func minimalCalendar() *ical.Calendar {
+	cal := ical.NewCalendar()
+	cal.Props.SetText(ical.PropVersion, "2.0")
+	cal.Props.SetText(ical.PropProductID, "-//go-webdav//test//EN")
+	ev := ical.NewEvent()
+	ev.Props.SetText(ical.PropUID, "test-uid")
+	ev.Props.SetDateTime(ical.PropDateTimeStamp, time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC))
+	cal.Children = append(cal.Children, ev.Component)
+	return cal
+}
+
+// TestPutCalendarObjectSendsIfMatch verifies the client forwards the
+// PutCalendarObjectOptions.IfMatch ETag as an If-Match request header and
+// returns the server's new ETag.
+func TestPutCalendarObjectSendsIfMatch(t *testing.T) {
+	var gotIfMatch string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotIfMatch = r.Header.Get("If-Match")
+		w.Header().Set("ETag", `"new-etag"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	opts := &PutCalendarObjectOptions{IfMatch: webdav.ConditionalMatch(`"old-etag"`)}
+	co, err := c.PutCalendarObject(context.Background(), "/cal/test-uid.ics", minimalCalendar(), opts)
+	if err != nil {
+		t.Fatalf("PutCalendarObject: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotIfMatch != `"old-etag"` {
+		t.Errorf("If-Match header = %q, want %q", gotIfMatch, `"old-etag"`)
+	}
+	if co.ETag != "new-etag" {
+		t.Errorf("returned ETag = %q, want %q", co.ETag, "new-etag")
+	}
+}
+
+// TestPutCalendarObjectNilOptsOmitsIfMatch verifies a nil opts (the
+// unconditional write) sends no If-Match header.
+func TestPutCalendarObjectNilOptsOmitsIfMatch(t *testing.T) {
+	var hadIfMatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadIfMatch = r.Header["If-Match"]
+		w.Header().Set("ETag", `"e"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := c.PutCalendarObject(context.Background(), "/cal/test-uid.ics", minimalCalendar(), nil); err != nil {
+		t.Fatalf("PutCalendarObject: %v", err)
+	}
+	if hadIfMatch {
+		t.Errorf("If-Match header present on unconditional PUT, want absent")
+	}
+}
+
+// TestPutCalendarObjectPreconditionFailed verifies a 412 response surfaces as
+// an error whose status code consumers can read via webdav.HTTPErrorCode.
+func TestPutCalendarObjectPreconditionFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	opts := &PutCalendarObjectOptions{IfMatch: webdav.ConditionalMatch(`"stale"`)}
+	_, err = c.PutCalendarObject(context.Background(), "/cal/test-uid.ics", minimalCalendar(), opts)
+	if err == nil {
+		t.Fatal("PutCalendarObject: want error on 412, got nil")
+	}
+	code, ok := webdav.HTTPErrorCode(err)
+	if !ok {
+		t.Fatalf("HTTPErrorCode: not an HTTP error: %v", err)
+	}
+	if code != http.StatusPreconditionFailed {
+		t.Errorf("status code = %d, want %d", code, http.StatusPreconditionFailed)
+	}
+}

--- a/carddav/client.go
+++ b/carddav/client.go
@@ -384,18 +384,16 @@ func (c *Client) GetAddressObject(ctx context.Context, path string) (*AddressObj
 	return ao, nil
 }
 
-func (c *Client) PutAddressObject(ctx context.Context, path string, card vcard.Card) (*AddressObject, error) {
-	// TODO: add support for If-None-Match and If-Match
-
+// PutAddressObject stores card as the address object resource at path. A nil
+// opts performs an unconditional PUT; a non-nil opts may carry an If-Match
+// (overwrite only if the resource still has this ETag) or If-None-Match
+// (create only if absent) precondition. A failed precondition surfaces as an
+// error whose status code is 412 Precondition Failed, readable via
+// webdav.HTTPErrorCode.
+func (c *Client) PutAddressObject(ctx context.Context, path string, card vcard.Card, opts *PutAddressObjectOptions) (*AddressObject, error) {
 	// TODO: some servers want a Content-Length header, so we can't stream the
 	// request body here. See the Radicale issue:
 	// https://github.com/Kozea/Radicale/issues/1016
-
-	//pr, pw := io.Pipe()
-	//go func() {
-	//	err := vcard.NewEncoder(pw).Encode(card)
-	//	pw.CloseWithError(err)
-	//}()
 
 	var buf bytes.Buffer
 	if err := vcard.NewEncoder(&buf).Encode(card); err != nil {
@@ -404,10 +402,17 @@ func (c *Client) PutAddressObject(ctx context.Context, path string, card vcard.C
 
 	req, err := c.ic.NewRequest(http.MethodPut, path, &buf)
 	if err != nil {
-		//pr.Close()
 		return nil, err
 	}
 	req.Header.Set("Content-Type", vcard.MIMEType)
+	if opts != nil {
+		if opts.IfMatch.IsSet() {
+			req.Header.Set("If-Match", string(opts.IfMatch))
+		}
+		if opts.IfNoneMatch.IsSet() {
+			req.Header.Set("If-None-Match", string(opts.IfNoneMatch))
+		}
+	}
 
 	resp, err := c.ic.Do(req.WithContext(ctx))
 	if err != nil {

--- a/carddav/client_ifmatch_test.go
+++ b/carddav/client_ifmatch_test.go
@@ -1,0 +1,78 @@
+package carddav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emersion/go-vcard"
+	"github.com/emersion/go-webdav"
+)
+
+func minimalCard() vcard.Card {
+	card := make(vcard.Card)
+	card.SetValue(vcard.FieldFormattedName, "Alice Gopher")
+	card.SetValue(vcard.FieldUID, "test-uid")
+	vcard.ToV4(card)
+	return card
+}
+
+// TestPutAddressObjectSendsIfMatch verifies the client forwards
+// PutAddressObjectOptions.IfMatch as an If-Match request header and returns the
+// server's new ETag.
+func TestPutAddressObjectSendsIfMatch(t *testing.T) {
+	var gotIfMatch, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotIfMatch = r.Header.Get("If-Match")
+		w.Header().Set("ETag", `"new-etag"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	opts := &PutAddressObjectOptions{IfMatch: webdav.ConditionalMatch(`"old-etag"`)}
+	ao, err := c.PutAddressObject(context.Background(), "/contacts/test-uid.vcf", minimalCard(), opts)
+	if err != nil {
+		t.Fatalf("PutAddressObject: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotIfMatch != `"old-etag"` {
+		t.Errorf("If-Match header = %q, want %q", gotIfMatch, `"old-etag"`)
+	}
+	if ao.ETag != "new-etag" {
+		t.Errorf("returned ETag = %q, want %q", ao.ETag, "new-etag")
+	}
+}
+
+// TestPutAddressObjectPreconditionFailed verifies a 412 response surfaces as an
+// error readable via webdav.HTTPErrorCode.
+func TestPutAddressObjectPreconditionFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(http.DefaultClient, srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	opts := &PutAddressObjectOptions{IfMatch: webdav.ConditionalMatch(`"stale"`)}
+	_, err = c.PutAddressObject(context.Background(), "/contacts/test-uid.vcf", minimalCard(), opts)
+	if err == nil {
+		t.Fatal("PutAddressObject: want error on 412, got nil")
+	}
+	code, ok := webdav.HTTPErrorCode(err)
+	if !ok {
+		t.Fatalf("HTTPErrorCode: not an HTTP error: %v", err)
+	}
+	if code != http.StatusPreconditionFailed {
+		t.Errorf("status code = %d, want %d", code, http.StatusPreconditionFailed)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package webdav
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -49,6 +50,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // (intended for humans).
 func NewHTTPError(statusCode int, cause error) error {
 	return &internal.HTTPError{Code: statusCode, Err: cause}
+}
+
+// HTTPErrorCode reports the HTTP status code associated with err, if any. It
+// returns (code, true) when err (or anything it wraps) carries an HTTP status —
+// including the errors the client returns for a non-2xx response — and
+// (0, false) otherwise. It lets a client consumer distinguish, for example, a
+// 412 Precondition Failed (a failed If-Match) from other failures without
+// reaching into the internal error type.
+func HTTPErrorCode(err error) (int, bool) {
+	var httpErr *internal.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Code, true
+	}
+	return 0, false
 }
 
 type backend struct {


### PR DESCRIPTION
## Motivation

`caldav.Client.PutCalendarObject` and `carddav.Client.PutAddressObject` send no conditional request headers, so a client cannot perform an optimistic-concurrency write — overwrite only if the resource still carries an expected ETag (`If-Match`), or create only if absent (`If-None-Match`). Both methods carried a `// TODO: add support for If-None-Match and If-Match`.

## Changes

- Add an options parameter to `PutCalendarObject` / `PutAddressObject`, **reusing the existing server-side `PutCalendarObjectOptions` / `PutAddressObjectOptions` types** so the client and `Backend` interface now mirror each other. A `nil` opts preserves the prior unconditional behaviour; a non-nil opts sets `If-Match` / `If-None-Match`.
- Add `webdav.HTTPErrorCode(err) (int, bool)`, so a client consumer can read the HTTP status off a returned error (e.g. distinguish `412 Precondition Failed` from other failures) without reaching into the `internal` error type — there is currently no public way to do this.

This is a breaking change to the two client method signatures (go-webdav is pre-1.0). Also removed some dead commented-out pipe code in `carddav/client.go` while there.

## Tests

Added `caldav/client_ifmatch_test.go` and `carddav/client_ifmatch_test.go` (httptest-backed): assert the `If-Match` header is sent, that a nil opts sends none, and that a 412 surfaces via `webdav.HTTPErrorCode`.

Signed-off-by: Henry Stern <henry@stern.ca>